### PR TITLE
This fixes #18 by including std::thread

### DIFF
--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -162,23 +162,27 @@ macro_rules! log_verbose {
 }
 
 
-#[test]
-fn test() {
-    log_info!("Test!");
-}
-
-//To-Do add a way to check the result automatically
-#[test]
-fn multi_thread_test() {
+#[cfg(test)]
+mod test {
     use std::thread;
+    // use super::*;
 
-    let mut joins = Vec::new();
-    for _ in 0..10 {
-        joins.push(thread::spawn(move || {
-            log_info!("No corruption should happen in this ultra-extra-super-long string output even if run in multiple threads.");
-        }));
+    #[test]
+    fn test() {
+        log_info!("Test!");
     }
-    for handle in joins {
-        let _ = handle.join();
+
+    //To-Do add a way to check the result automatically
+    #[test]
+    fn multi_thread_test() {
+        let mut joins = Vec::new();
+        for _ in 0..10 {
+            joins.push(thread::spawn(move || {
+                log_info!("No corruption should happen in this ultra-extra-super-long string output even if run in multiple threads.");
+            }));
+        }
+        for handle in joins {
+            let _ = handle.join();
+        }
     }
 }

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -170,9 +170,11 @@ fn test() {
 //To-Do add a way to check the result automatically
 #[test]
 fn multi_thread_test() {
+    use std::thread;
+
     let mut joins = Vec::new();
     for _ in 0..10 {
-        joins.push(std::thread::spawn(move || {
+        joins.push(thread::spawn(move || {
             log_info!("No corruption should happen in this ultra-extra-super-long string output even if run in multiple threads.");
         }));
     }


### PR DESCRIPTION
By including std::thread _inside_ the test function, `cargo test` has
access to all required modules while not generating a warning for unused
imports when issuing `cargo build`.

Using this reveals different problems as described in  https://github.com/Drakulix/zwreec/issues/18#issuecomment-97899101 at the bottom.
