### PR TITLE
Use Rust Nightly (2015-05-01)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: 1.0.0-beta.3
+rust: nightly-2015-05-01
 branches:
   only:
     - master


### PR DESCRIPTION
I _believe_ this should work: Travis CI seems to use `rustup.sh` to
install the required Rust version by specifing `--spec=%s` where `%s`
corresponst to the provided rust version. Using `rustup.sh
--spec=nightly-2015-05-01` seems to work locally, so it just might also
work on Travis CI.

(Ich hab mir dafür tatsächlich Travis CI Source Code durchlesen müssen ._. In der normalen Doku stand nicht, wie genau man spezifische Version angibt. _eyesroll_)
