### PR TITLE
fixes #39

### DIFF
--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -174,7 +174,7 @@ rustlex! TweeLexer {
 	let TEXT_INITIAL = INITIAL_START_CHAR INITIAL_CHAR*;
 
 	// If for example // is at a beginning of a line, then // is matched and not just /
-	let TEXT_START_CHAR = [^"*!>#"'\n'];
+	let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ" | [^"*!>#"'\n']; // add chars longer than one byte
 	let TEXT_CHAR = [^"/'_=~^{@<[" '\n'];
 	let TEXT = TEXT_CHAR+ | ["/'_=^{@<["];
 


### PR DESCRIPTION
include chars consisting of more than one byte in definition of TEXT_START_CHAR

as rustlex works on bytes and TEXT_START_CHAR is defined to match anything except of certain signs [^"*!>#"'\n'], it also matches the first half of multi-byte utf8 chars which leads to errors when unwrap is called on them in yystr
