### PR TITLE
Switch to rust nightly 2015-05-15(16?)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: rust
-rust: nightly-2015-05-01
+rust: nightly-2015-05-16
 branches:
   only:
     - master

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 Twee to Z-Code Compiler written in the Rust programming language. This is intended to compile [interactive fiction](http://en.wikipedia.org/wiki/Interactive_fiction) in the Twee format (created by the [Twine software](http://en.wikipedia.org/wiki/Twine_(software))) to [Z-Machine](http://en.wikipedia.org/wiki/Z-machine) instructions that can be run with Z-Code interpreters like [frotz](http://frotz.sourceforge.net).
 
 ## Usage
-*This uses rust nightly (currently tested with 2015-05-01). This depends on compiler plugins and can therefore not use any stable builds at the moment. Sorry for any inconvenience.*
+*This uses rust nightly (currently tested with 2015-05-16). This depends on compiler plugins and can therefore not use any stable builds at the moment. Sorry for any inconvenience.*
 
 ```
 Usage: target/debug/zwreec_bin [-hV] [-vq] [-l [LOGFILE]] [-o OUTPUT] INPUT


### PR DESCRIPTION
This uses the the nightly build, that was released right after the first 1.0.0 stable release.

```
rustc 1.1.0-nightly (7a52835c1 2015-05-16) (built 2015-05-15)
```
