### PR TITLE
Refactor compile arguments to not rely on files

### DIFF
--- a/src/bin/zwreec.rs
+++ b/src/bin/zwreec.rs
@@ -122,7 +122,7 @@ fn main() {
         let path = Path::new(&parsed_opts.free[0]);
         match File::open(path) {
             Err(why) => {
-                panic!("couldn't open {}: {}",
+                panic!("Couldn't open {}: {}",
                                path.display(), Error::description(&why))
             },
             Ok(file) => {
@@ -142,9 +142,9 @@ fn main() {
         // parsed "-o FILE"
         // try to open FILE
         let path = Path::new(&file);
-        match File::open(path) {
+        match File::create(path) {
             Err(why) => {
-                panic!("couldn't open {}: {}",
+                panic!("Couldn't open {}: {}",
                        path.display(), Error::description(&why))
             },
             Ok(file) => {
@@ -155,9 +155,9 @@ fn main() {
     } else {
         // assume default
         let path = Path::new("a.z8");
-        match File::open(path) {
+        match File::create(path) {
             Err(why) => {
-                panic!("couldn't open {}: {}",
+                panic!("Couldn't open {}: {}",
                        path.display(), Error::description(&why))
             },
             Ok(file) => {
@@ -171,8 +171,8 @@ fn main() {
     // activate logger
     let _ = logger::CombinedLogger::init(loggers);
 
-    debug!("parsed command line options");
-    info!("main started");
+    debug!("Parsed command line options");
+    info!("Main started");
 
     // call library
     zwreec::compile(&mut infile, &mut outfile);
@@ -181,5 +181,5 @@ fn main() {
     debug!("(2) {}", zwreec::backend::temp_hello());
     debug!("(3) {}", zwreec::utils::file::temp_hello());
 
-    info!("main finished");
+    info!("Main finished");
 }

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -1,14 +1,21 @@
 //! The `codegen` module is for the creating of zcode from an ast
 
+use std::error::Error;
+use std::io::Write;
 use frontend::ast;
 use super::super::backend::zcode::zfile;
-use utils::file;
 
-pub fn generate_zcode(ast: ast::AST, output_file_name: &str) {
-
+pub fn generate_zcode<W: Write>(ast: ast::AST, output: &mut W) {
     let mut codegenerator = Codegen::new(ast);
     codegenerator.start_codegen();
-    file::save_bytes_to_file(output_file_name, &(*codegenerator.zfile_bytes()) );
+    match output.write_all(&(*codegenerator.zfile_bytes())) {
+        Err(why) => {
+            panic!("Could not write to output: {}", Error::description(&why));
+        },
+        Ok(_) => {
+            info!("Wrote zcode to output");
+        }
+    };
 }
 
 struct Codegen {

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -1,4 +1,5 @@
-use std::io::BufReader;
+use std::error::Error;
+use std::io::{BufReader,Read};
 use self::Token::{
 	TokPassageName, TokTagStart, TokTagEnd, TokTag,
 	TokMakroStart, TokMakroEnd, TokVariable,
@@ -16,8 +17,15 @@ use self::Token::{
 	TokArrayStart, TokArrayEnd, TokNewLine, TokFormatHorizontalLine
 };
 
-pub fn lex(input :String) -> Vec<Token> {
-	let processed = preprocess(input);
+pub fn lex<R: Read>(input: &mut R) -> Vec<Token> {
+    // TODO: Instead of reading the entire input, work on BufRead or Read directly
+    let mut content = String::new();
+    match input.read_to_string(&mut content) {
+        Err(why) => panic!("could not read from input: {}", Error::description(&why)),
+        Ok(_) => debug!("read input to buffer"),
+    };
+
+	let processed = preprocess(content);
    	let inp = BufReader::new(processed.as_bytes());
    	print!("Nicht in Tokens verarbeitete Zeichen: ");
 	let mut lexer = TweeLexer::new(inp);
@@ -52,8 +60,9 @@ pub fn lex(input :String) -> Vec<Token> {
 	tokens
 }
 
-// TODO do not remove if in passage name, monospace etc. 
-fn preprocess(input :String) -> String {
+// TODO: do not remove if in passage name, monospace etc. 
+// TODO: Work on Read or BufRead instead of Strings
+fn preprocess(input: String) -> String {
 	let mut comment = false;
 	let mut suspect_start = false;
 	let mut suspect_end = false;

--- a/src/zwreec/frontend/mod.rs
+++ b/src/zwreec/frontend/mod.rs
@@ -4,10 +4,6 @@ pub mod ast;
 pub mod parsetree;
 pub mod codegen;
 
-pub fn lex<T: Iterator>(input :String)-> Vec<lexer::Token> {
-    lexer::lex(input)
-}
-
 /// only temp-method, tests/lib.rs checks it
 pub fn temp_hello() -> String {
     "hello from frontend".to_string()

--- a/src/zwreec/lib.rs
+++ b/src/zwreec/lib.rs
@@ -6,23 +6,18 @@ extern crate rustlex;
 extern crate time;
 extern crate term;
 
-pub use backend::zcode::zfile;
-
-
 pub mod frontend;
 pub mod backend;
+pub use backend::zcode::zfile;
 pub mod utils;
+
 use frontend::codegen;
 
+use std::io::{Read,Write};
 
-pub fn compile(input_file_name: &str, output_file_name: &str) {
-    info!("inputFile: {}", input_file_name);
-    info!("outputFile: {}", output_file_name);
 
+pub fn compile<R: Read, W: Write>(input: &mut R, output: &mut W) {
     // compile
-
-    // read file
-    let input = utils::file::open_source_file(input_file_name);
 
     // tokenize
     let tokens = frontend::lexer::lex(input);
@@ -37,9 +32,7 @@ pub fn compile(input_file_name: &str, output_file_name: &str) {
     ast.print();
 
     // create code
-    codegen::generate_zcode(ast, output_file_name);
-
-    //backend::zcode::temp_create_zcode_example();
+    codegen::generate_zcode(ast, output);
 }
 
 #[test]


### PR DESCRIPTION
This rewrites parts of the binary and the library frontend to use the
Read and Write traits instead of filenames as arguments. This way it is
possible to also provide Buffers, Pipes, or Streams like STDIN as source
or output.

This closes #24. 

This was a lot more complicated, than I anticipated. For example, I have no clue why the `Read`-Reference needs to be mutable to be converted to a string. I would like to ask someone who is more knowledgable in rust than I am to look over this code more closely.
