### PR TITLE
solve utf8-bug

### DIFF
--- a/src/zwreec/frontend/screener.rs
+++ b/src/zwreec/frontend/screener.rs
@@ -17,23 +17,25 @@ pub fn screen<R: Read>(input: &mut R) -> Cursor<Vec<u8>> {
         Ok(_) => debug!("read input to buffer"),
     };
 
-    Cursor::new(content.chars().peeking().scan_filter(
+    Cursor::new(content.bytes().peeking().scan_filter(
         ScanState {
             comment: false,
             skip_next: false,
         },
         |state, elem| {
+            const SLASH: u8 = '/' as u8;
+            const PERCENT: u8 = '%' as u8;
             match (state.comment, state.skip_next, elem) {
                 (_, true, _) => { //skipping
                     state.skip_next = false;
                     None
                 },
-                (false, _, ('/', Some('%'))) => { //comment_start
+                (false, _, (SLASH, Some(PERCENT))) => { //comment_start
                     state.comment = true;
                     state.skip_next = true;
                     None
                 },
-                (true, _, ('%', Some('/'))) => { //comment_end
+                (true, _, (PERCENT, Some(SLASH))) => { //comment_end
                     state.comment = false;
                     state.skip_next = true;
                     None


### PR DESCRIPTION
behebt #71.
der absturz selber tritt in rustlex/codegen.rs auf. ein String::from_utf8(Vec<u8>) erstellt aus mehreren bytes ein utf8-string, wenn es sich aber nicht um utf8-valide bytes handelt gibt das ding eine fehlermeldung. mit der kann ".unwrap()" nicht umgehen und panict.
im screener wurde content in chars geteilt und nicht in bytes. chars sind in rust aber nicht 8bits, sondern beinhalten einen unicode scalar value. ein zeichen was aus mehreren bytes bestand wurde zu einem byte reduziert, was dann bei der zurückrechnung von bytes in utf8 natürlich so nicht funktioniert.

an der umsetzung mit den "const"s kann vermutlich noch was verschönert werden
