### PR TITLE
Add simple support for unicode

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -199,6 +199,31 @@ impl Zfile {
         self.labels.push(label);
     }
 
+    /// generates normal print opcodes for ASCII characters and unicode print
+    /// opcodes for unicode characters
+    pub fn gen_print_ops(&mut self, text: &str) {
+        let mut current_text: String = String::new();
+        for character in text.chars() {
+            if character as u32 <= 126 {
+                // this is a non-unicode char
+                current_text.push(character);
+            } else {
+                debug!("Printing unicode char {}", character.to_string());
+                // unicode
+                if current_text.len() > 0 {
+                    self.op_print(&current_text[..]);
+                    current_text.clear();
+                }
+
+                self.op_print_unicode_char(character);
+            }
+        }
+
+        if current_text.len() > 0 {
+            self.op_print(&current_text[..]);
+        }
+    }
+
     // ================================
     // no op-commands
 

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -30,7 +30,7 @@ fn gen_zcode(node: &ASTNode, state: FormattingState, mut out: &mut zfile::Zfile)
         &ASTNode::Default(ref t) => {
             match &t.category {
                 &Token::TokText(ref s) => {
-                    out.op_print(s);
+                    out.gen_print_ops(s);
                 },
                 &Token::TokNewLine => {
                     out.op_newline();

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -33,6 +33,11 @@ fn helloworld_test() {
 }
 
 #[test]
+fn long_text_test() {
+    test_compile(TESTFOLDER.to_string() + "HelloWorld.twee");
+}
+
+#[test]
 fn zscii_test() {
 	test_compile(TESTFOLDER.to_string() + "ZSCII.twee");
 }
@@ -40,4 +45,9 @@ fn zscii_test() {
 #[test]
 fn ascii_test() {
 	test_compile(TESTFOLDER.to_string() + "ASCII.twee");
+}
+
+#[test]
+fn unicode_test() {
+    test_compile(TESTFOLDER.to_string() + "Unicode.twee");
 }

--- a/tests/integration/sample/LongText.twee
+++ b/tests/integration/sample/LongText.twee
@@ -1,0 +1,2 @@
+::Start
+This is a sample text with a very long line. This line is used to demonstrate that the compiler doesn't produce garbage if there is more than a few characters per line. As you can see everything is fine. This text also contains umlauts: ö and other special characters: ♫♬

--- a/tests/integration/sample/Unicode.twee
+++ b/tests/integration/sample/Unicode.twee
@@ -1,0 +1,65 @@
+::Start
+We currently support a wide range of Unicode characters. The Z-Machine has support for all unicode characters from 0x0 to 0xffffffff. These are excerpts from multiple Unicode Code pages.
+
+U+00000000 Basic Latin:
+ !"#$%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\]_'abcdefghijklmnopqrstuvwxyz{|}~
+
+U+00000080 Latin Supplements and Extended:
+ äöüÖÄÜßẞéèêîíìçáàânñnńiïÀÁÂÃĀĂȦÄẢÅǍȀȂĄẠḀẦẤẪẨẰẮẴẲǠǞǺẬẶȺⱭÆǼǢ
+
+U+00000370 Greek and Coptic:
+ ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡΣΤΥΦΧΨΩαβγδεζηθικλμνξοπρστυφχψωⲀⲂⲄⲆⲈⲊⲌ
+
+U+00000400 Cyrillic and Supplements:
+ АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯабвгдежзийклмнопрстуфхцчшщъыьэюяӐӁӜЉҨӝҩ҈꙲
+
+U+00000530 Armenian:
+ ԱԲԳԴԵԶԷ
+
+U+00000590 Hebrew:
+ אבדהזש
+
+Georgian:
+ ႠႡႢႣႤႥႦ
+
+Arrows:
+ →←↑↓➤
+
+Parentheses:
+ 〖〗⎝⎠
+
+Punctuation:
+ ¿?%‰‱❝❞
+
+Currency Symbols:
+ $€¥¢£₽₩฿₺₮₱₭₴₦৲৳૱௹﷼₹₲₪₡₫៛₵₢₸₤₳₥₠₣₰₧₯₶₷
+
+Pictographs:
+ ☼☆♠︎♣︎♥︎♦︎
+
+Bullets/Stars:
+ ∙・◎◉☑︎☒
+
+Math Symbols:
+ +−×÷±∓⊂⊃⊆⊇∈∉∫
+
+Letterlike Symbols:
+ ®©℗™℠№℅
+
+Sign/Standard Symbols:
+ ✆♳♴♺
+
+Technical Symbols:
+ ⌘⎋⏎⏏⌤⌥⌃⌄⌅⌆⌀⌁⌂⌐⌦⌧⌫⎛⎞⎝⎠⎡⎤⎩⎭
+
+Enclosed Characters:
+ ⒜⒝⒞⒟⒠⒡⒢ⒶⒷⒸⒹⒺⒻⒼ
+
+Divination Symbols:
+ ☰☱☲☳䷉
+
+Musical Symbols:
+ ♩♪♫♬♭𝄫♮♯
+
+Braille Patterns:
+ ⠁⠇⠖⠥⠵⠽⡅


### PR DESCRIPTION
This does not include support for the unicode translation table.
It mereley detects unicode characters in the AST and generates corresponding
print_unicode_char opcodes. This does not seem to work with "frotz" for
example.
Interpreters such as "Zoom" work.
