### PR TITLE
Feature Variablenzuweisung

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -604,7 +604,6 @@ impl Zfile {
 
     /// encodes the argtypes for variable some 2OPs and varOPs
     fn encode_variable_arguments(&mut self, arg_types: Vec<ArgType>) -> u8 {
-        println!("encode_variable_arguments");
         let mut byte: u8 = 0x00;
         for (i, arg_type) in arg_types.iter().enumerate() {
             let shift: u8 = 6 - 2 * i as u8;

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -364,6 +364,15 @@ impl Zfile {
         self.data.append_byte(value);
     }
 
+    // saves an u16 to the variable
+    pub fn op_store_u16(&mut self, variable: u8, value: u16) {
+        let args: Vec<ArgType> = vec![ArgType::Reference, ArgType::LargeConst];
+        self.op_2(0x0d, args);
+
+        self.data.append_byte(variable);
+        self.data.append_u16(value);
+    }
+
     /// increments the value of the variable
     pub fn op_inc(&mut self, variable: u8) {
         self.op_1(0x05, ArgType::Reference);
@@ -595,6 +604,7 @@ impl Zfile {
 
     /// encodes the argtypes for variable some 2OPs and varOPs
     fn encode_variable_arguments(&mut self, arg_types: Vec<ArgType>) -> u8 {
+        println!("encode_variable_arguments");
         let mut byte: u8 = 0x00;
         for (i, arg_type) in arg_types.iter().enumerate() {
             let shift: u8 = 6 - 2 * i as u8;
@@ -603,7 +613,8 @@ impl Zfile {
                 &ArgType::SmallConst => byte |= 0x01 << shift,
                 &ArgType::Variable   => byte |= 0x02 << shift,
                 &ArgType::Nothing    => byte |= 0x03 << shift,
-                _                    => panic!("no possible varOP")
+                &ArgType::Reference  => byte |= 0x01 << shift,
+                //_                    => panic!("no possible varOP")
             }
         }
 

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -65,7 +65,7 @@ fn gen_zcode<'a>(node: &'a ASTNode, state: FormattingState, mut out: &mut zfile:
                     out.op_set_text_style(state_copy.bold, state_copy.inverted, state_copy.mono, state_copy.italic);
                 },
                 &Token::TokAssign(ref var, ref operator) => {
-                    if operator == "=" {
+                    if operator == "=" || operator == "to" {
                         if !var_table.contains_key::<str>(var) {
                             var_table.insert(&var, *var_id);
                             debug!("Assigned id {} to variable {}", var_id, var);

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -124,7 +124,7 @@ impl AST {
     /// convert ast to zcode
     pub fn to_zcode(&self,  out: &mut zfile::Zfile) {
         let mut var_table = HashMap::<&str, u8>::new();
-        let mut var_id : u8 = 100;
+        let mut var_id : u8 = 25;
         let state = FormattingState {bold: false, italic: false, mono: false, inverted: false};
         for child in &self.passages {
             gen_zcode(child, state, out, &mut var_table, &mut var_id);

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -4,6 +4,7 @@
 use frontend::lexer::Token;
 use backend::zcode::zfile;
 use backend::zcode::zfile::{FormattingState};
+use std::collections::HashMap;
 
 //==============================
 // ast
@@ -15,6 +16,8 @@ pub struct AST {
 /// add zcode based on tokens
 fn gen_zcode(node: &ASTNode, state: FormattingState, mut out: &mut zfile::Zfile) {
     let mut state_copy = state.clone();
+    let mut var_table = HashMap::<&str, u8>::new();
+    let mut var_id : u8 = 100;
 
     match node {
         &ASTNode::Passage(ref node) => {
@@ -60,8 +63,15 @@ fn gen_zcode(node: &ASTNode, state: FormattingState, mut out: &mut zfile::Zfile)
                     out.op_print_num_var(16);
                     out.op_print("]");
                     out.op_set_text_style(state_copy.bold, state_copy.inverted, state_copy.mono, state_copy.italic);
-                    
-
+                },
+                &Token::TokAssign(ref var, ref operator) => {
+                    if operator == "=" {
+                        if !var_table.contains_key::<str>(var) {
+                            var_table.insert(&var, var_id);
+                            var_id += 1;
+                        }
+                        let id = var_table.get::<str>(var);
+                    }
                 },
                 _ => {
                     debug!("no match 2");

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -85,7 +85,8 @@ fn gen_zcode<'a>(node: &'a ASTNode, state: FormattingState, mut out: &mut zfile:
                                     };
                                     match def.category {
                                         Token::TokInt(value) => {
-                                            out.op_store_u8(actual_id, value as u8);
+                                            out.op_store_u16(actual_id, value as u16);
+                                            out.op_print_num_var(actual_id);
                                         },
                                         Token::TokBoolean(ref bool_val) => {
                                             let value = match (*bool_val).as_ref() {

--- a/src/zwreec/lib.rs
+++ b/src/zwreec/lib.rs
@@ -33,4 +33,6 @@ pub fn compile<R: Read, W: Write>(input: &mut R, output: &mut W) {
 
     // create code
     codegen::generate_zcode(ast, output);
+
+    //backend::zcode::temp_create_zcode_example();
 }


### PR DESCRIPTION
Es wird nun unterstützt Byte -oder Booleanwerte in twee zu setzen.

Closes #85, #86 

Beispiele:

```
<<set $one=1>>
<<set $two=2>>
<<set $true=true>>
<<set $false=false>>
```

Eventuell sollten vor dem Merge noch int-Werte unterstützt werden.
