### PR TITLE
Feature/short display macro support

### DIFF
--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -160,7 +160,7 @@ rustlex! TweeLexer {
 
 	let MAKRO_START = "<<";
 	let MAKRO_END = ">>";
-	let MAKRO_PANIC = ["[]<:|"] [^" >"]*;
+	let MAKRO_PANIC = ["[]<:|"] [^" >"'\n']*;
 
 	let BR_OPEN = '(';
 	let BR_CLOSE = ')';
@@ -181,7 +181,7 @@ rustlex! TweeLexer {
 
 	let FUNCTION = LETTER+ '(';
 
-	let MACRO_NAME = LETTER+ WHITESPACE*;
+	let MACRO_NAME = [^" >"'\n']*;
 
 	let ASSIGN = "=" | "to" | "+=" | "-=" | "*=" | "/=";
 	let SEMI_COLON = ';';

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -160,7 +160,6 @@ rustlex! TweeLexer {
 
 	let MAKRO_START = "<<";
 	let MAKRO_END = ">>";
-	let MAKRO_PANIC = ["[]<:|"] [^" >"'\n']*;
 
 	let BR_OPEN = '(';
 	let BR_CLOSE = ')';
@@ -459,10 +458,6 @@ rustlex! TweeLexer {
 		VAR_NAME =>  |lexer:&mut TweeLexer<R>| {
 			lexer.MAKRO_CONTENT();
 			Some(TokMakroVar(lexer.yystr()))
-		}
-
-		MAKRO_PANIC =>  |lexer:&mut TweeLexer<R>| -> Option<Token> {
-			panic!("No macro called \"{}\"", lexer.yystr());
 		}
 	}
 

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -742,9 +742,15 @@ mod tests {
 	}
 
 	#[test]
-	#[should_panic]
-	fn macro_invalid_test() {
+	fn macro_display_short_test() {
 		// Should fail because it contains an invalid macro
-		test_lex("::Passage\n<<invalid>>");
+		let tokens = test_lex("::Passage\n<<Passage>>");
+		let expected = vec![
+			TokPassageName("Passage".to_string()),
+			TokMakroPassageName("Passage".to_string()),
+			TokMakroEnd
+		];
+
+		assert_eq!(expected, tokens);
 	}
 }

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -136,7 +136,7 @@ impl Parser {
                     // ast
                     self.ast.add_child(&self.ast_path, TokText(text.clone()));
                 },
-                (PassageContent, &TokFormatBoldStart) | 
+                (PassageContent, &TokFormatBoldStart) |
                 (PassageContent, &TokFormatItalicStart) |
                 (PassageContent, &TokFormatMonoStart) => {
                     new_nodes.push(PNode::new_non_terminal(Formating));
@@ -156,7 +156,8 @@ impl Parser {
                 (PassageContent, &TokSet) |
                 (PassageContent, &TokIf) |
                 (PassageContent, &TokVariable(_)) |
-                (PassageContent, &TokMakroVar(_)) => {
+                (PassageContent, &TokMakroVar(_)) |
+                (PassageContent, &TokMakroPassageName(_)) => {
                     new_nodes.push(PNode::new_non_terminal(Makro));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
                 },
@@ -280,7 +281,14 @@ impl Parser {
                     // ast
                     self.ast.add_child(&self.ast_path, TokMakroVar(name.clone()));
                 },
+                // means <<passagename>>
+                (Makro, &TokMakroPassageName(ref name)) => {
+                    new_nodes.push(PNode::new_terminal(TokMakroPassageName(name.clone())));
+                    new_nodes.push(PNode::new_terminal(TokMakroEnd));
 
+                    // ast
+                    self.ast.add_child(&self.ast_path, TokMakroPassageName(name.clone()));
+                },
                 // Makrof
                 (Makrof, &TokElse) => {
                     new_nodes.push(PNode::new_terminal(TokElse));
@@ -323,7 +331,7 @@ impl Parser {
                 (ExpressionListf, &TokMakroEnd) => {
                     debug!("pop TokMakroEnd");
                     self.ast_path.pop();
-                    
+
                 },
                 (ExpressionListf, _) => {
                     // ExpressionListf -> ε
@@ -462,7 +470,7 @@ impl Parser {
                     self.ast.add_child(&self.ast_path, TokBoolean(value.clone()));
                 }
 
-                
+
                 _ => {
                     panic!("not supported grammar: {:?}", state_first);
                 }
@@ -476,7 +484,7 @@ impl Parser {
         } else {
             // no token left
 
-            // Sf, PassageContent, Linkf, 
+            // Sf, PassageContent, Linkf,
 
             match top {
                 Sf | PassageContent => {

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -58,11 +58,11 @@ fn current_status_test() {
     test_compile(TESTFOLDER_PASS.to_string() + "CurrentStatus.twee");
 }
 
-#[test]
-#[should_panic]
-fn invalid_macro_test() {
-    test_compile(TESTFOLDER_FAIL.to_string() + "InvalidMacro.twee");
-}
+// #[test]
+// #[should_panic]
+// fn invalid_macro_test() {
+//    test_compile(TESTFOLDER_FAIL.to_string() + "InvalidMacro.twee");
+// }
 
 #[test]
 #[should_panic]


### PR DESCRIPTION
Support für << passagename >> (kurze Form für << display passagename >>) im Lexer und Parser
Sollte aber nicht vor Donnerstag Abend gemerged werden, das zerstört einen Test von @Farthen und ich hab noch was zu klären
