### PR TITLE
unicode table

### DIFF
--- a/src/zwreec/backend/zcode/mod.rs
+++ b/src/zwreec/backend/zcode/mod.rs
@@ -20,7 +20,7 @@ pub fn temp_create_zcode_example<W: Write>(output: &mut W) {
     zfile.op_call_1n("Start");
 
     zfile.routine("Start", 0);
-    zfile.op_print("start passage");
+    zfile.gen_print_ops("start passage");
     zfile.op_newline();
 
 


### PR DESCRIPTION
implement the unicode table, so we need op_print_unicode_char only if there are more than 97 different unicodes
the unicode table is written in the 195 bytes after the header-extension and before the global variables
no more static memory
highmemory starts at the programm counter

would fix the oldest of our issues: #34 
