### PR TITLE
Adds a file location parameter to every token.

### DIFF
--- a/src/bin/logger/filelog.rs
+++ b/src/bin/logger/filelog.rs
@@ -66,7 +66,7 @@ impl Log for FileLogger {
             let _ = match record.level() {
                 LogLevel::Trace => {
                     writeln!(file_lock,
-                        "[{}] {}: ({}:{}:{}) [{}:{}] - {}",
+                        "[{}] {}: ({:02}:{:02}:{:02}) [{}:{}] - {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,
@@ -79,7 +79,7 @@ impl Log for FileLogger {
                 },
                 _ => {
                     writeln!(file_lock,
-                        "[{}] {}: ({}:{}:{}) - {}",
+                        "[{}] {}: ({:02}:{:02}:{:02}) - {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,

--- a/src/bin/logger/simplelog.rs
+++ b/src/bin/logger/simplelog.rs
@@ -65,7 +65,7 @@ impl Log for SimpleLogger {
             let _ = match record.level() {
                 LogLevel::Trace =>
                     writeln!(stderr_lock,
-                        "[{}] {}: ({}:{}:{}) [{}:{}] - {}",
+                        "[{}] {}: ({:02}:{:02}:{:02}) [{}:{}] - {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,
@@ -77,7 +77,7 @@ impl Log for SimpleLogger {
                     ),
                 _ =>
                     writeln!(stderr_lock,
-                        "[{}] {}: ({}:{}:{}) - {}",
+                        "[{}] {}: ({:02}:{:02}:{:02}) - {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,

--- a/src/bin/logger/termlog.rs
+++ b/src/bin/logger/termlog.rs
@@ -63,77 +63,103 @@ impl Log for TermLogger {
 
             let cur_time = time::now();
 
-            let _ = match record.level() {
-                LogLevel::Error => {
-                    write!(stderr_lock, "[").unwrap();
-                    stderr_lock.fg(color::RED).unwrap();
-                    write!(stderr_lock, "{}", record.level()).unwrap();
-                    let _ = stderr_lock.reset();
-                    writeln!(stderr_lock,
-                        "] {}: ({}:{}:{}) - {}",
-                            record.target(),
-                            cur_time.tm_hour,
-                            cur_time.tm_min,
-                            cur_time.tm_sec,
-                            record.args()
-                    ).unwrap();
-                },
-                LogLevel::Warn => {
-                    write!(stderr_lock, "[").unwrap();
-                    stderr_lock.fg(color::YELLOW).unwrap();
-                    write!(stderr_lock, "{}", record.level()).unwrap();
-                    let _ = stderr_lock.reset();
-                    writeln!(stderr_lock,
-                        "] {}: ({}:{}:{}) - {}",
-                            record.target(),
-                            cur_time.tm_hour,
-                            cur_time.tm_min,
-                            cur_time.tm_sec,
-                            record.args()
-                    ).unwrap();
-                },
-                LogLevel::Info => {
-                    write!(stderr_lock, "[").unwrap();
-                    stderr_lock.fg(color::BLUE).unwrap();
-                    write!(stderr_lock, "{}", record.level()).unwrap();
-                    let _ = stderr_lock.reset();
-                    writeln!(stderr_lock,
-                        "] {}: ({}:{}:{}) - {}",
-                            record.target(),
-                            cur_time.tm_hour,
-                            cur_time.tm_min,
-                            cur_time.tm_sec,
-                            record.args()
-                    ).unwrap();
-                },
-                LogLevel::Debug => {
-                    write!(stderr_lock, "[").unwrap();
-                    stderr_lock.fg(color::CYAN).unwrap();
-                    write!(stderr_lock, "{}", record.level()).unwrap();
-                    let _ = stderr_lock.reset();
-                    writeln!(stderr_lock,
-                        "] {}: ({}:{}:{}) - {}",
-                            record.target(),
-                            cur_time.tm_hour,
-                            cur_time.tm_min,
-                            cur_time.tm_sec,
-                            record.args()
-                    ).unwrap();
-                },
-                LogLevel::Trace => {
-                    writeln!(stderr_lock,
-                        "[{}] {}: ({}:{}:{}) [{}:{}] - {}",
-                            record.level(),
-                            record.target(),
-                            cur_time.tm_hour,
-                            cur_time.tm_min,
-                            cur_time.tm_sec,
-                            record.location().file(),
-                            record.location().line(),
-                            record.args()
-                    ).unwrap();
-                },
-            };
+            if self.level() <= LogLevel::Warn {
+                let _ = match record.level() {
+                    LogLevel::Error => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::RED).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}",
+                                record.args()
+                        ).unwrap();
+                    },
+                    LogLevel::Warn => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::YELLOW).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}",
+                                record.args()
+                        ).unwrap();
+                    },
+                    _ => {}
+                };
+            } else {
+                let _ = match record.level() {
+                    LogLevel::Error => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::RED).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}: ({:02}:{:02}:{:02}) - {}",
+                                record.target(),
+                                cur_time.tm_hour,
+                                cur_time.tm_min,
+                                cur_time.tm_sec,
+                                record.args()
+                        ).unwrap();
+                    },
+                    LogLevel::Warn => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::YELLOW).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}: ({:02}:{:02}:{:02}) - {}",
+                                record.target(),
+                                cur_time.tm_hour,
+                                cur_time.tm_min,
+                                cur_time.tm_sec,
+                                record.args()
+                        ).unwrap();
+                    },
+                    LogLevel::Info => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::BLUE).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}: ({:02}:{:02}:{:02}) - {}",
+                                record.target(),
+                                cur_time.tm_hour,
+                                cur_time.tm_min,
+                                cur_time.tm_sec,
+                                record.args()
+                        ).unwrap();
+                    },
+                    LogLevel::Debug => {
+                        write!(stderr_lock, "[").unwrap();
+                        stderr_lock.fg(color::CYAN).unwrap();
+                        write!(stderr_lock, "{}", record.level()).unwrap();
+                        let _ = stderr_lock.reset();
+                        writeln!(stderr_lock,
+                            "] {}: ({:02}:{:02}:{:02}) - {}",
+                                record.target(),
+                                cur_time.tm_hour,
+                                cur_time.tm_min,
+                                cur_time.tm_sec,
+                                record.args()
+                        ).unwrap();
+                    },
+                    LogLevel::Trace => {
+                        writeln!(stderr_lock,
+                            "[{}] {}: ({:02}:{:02}:{:02}) [{}:{}] - {}",
+                                record.level(),
+                                record.target(),
+                                cur_time.tm_hour,
+                                cur_time.tm_min,
+                                cur_time.tm_sec,
+                                record.location().file(),
+                                record.location().line(),
+                                record.args()
+                        ).unwrap();
+                    },
+                };
+            }
 
             stderr_lock.flush().unwrap();
         }

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -30,7 +30,7 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
         &ASTNode::Passage(ref node) => {
             let mut code: Vec<ZOP> = vec![];
             match &node.category {
-                &Token::TokPassage {ref name} => {
+                &Token::TokPassage {ref name, .. } => {
                     code.push(ZOP::Routine{name: name.to_string(), count_variables: 0});
                 },
                 _ => {
@@ -51,28 +51,28 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
         },
         &ASTNode::Default(ref t) => {
             let mut code: Vec<ZOP> = match &t.category {
-                &Token::TokText {ref text} => {
+                &Token::TokText {ref text, .. } => {
                     vec![ZOP::PrintOps{text: text.to_string()}]
                 },
-                &Token::TokNewLine => {
+                &Token::TokNewLine { .. } => {
                     vec![ZOP::Newline]
                 },
-                &Token::TokFormatBoldStart => {
+                &Token::TokFormatBoldStart { .. } => {
                     state_copy.bold = true;
                     set_formatting = true;
                     vec![ZOP::SetTextStyle{bold: state_copy.bold, reverse: state_copy.inverted, monospace: state_copy.mono, italic: state_copy.italic}]
                 },
-                &Token::TokFormatMonoStart => {
+                &Token::TokFormatMonoStart { .. } => {
                     state_copy.mono = true;
                     set_formatting = true;
                     vec![ZOP::SetTextStyle{bold: state_copy.bold, reverse: state_copy.inverted, monospace: state_copy.mono, italic: state_copy.italic}]
                 },
-                &Token::TokFormatItalicStart => {
+                &Token::TokFormatItalicStart { .. } => {
                     state_copy.italic = true;
                     set_formatting = true;
                     vec![ZOP::SetTextStyle{bold: state_copy.bold, reverse: state_copy.inverted, monospace: state_copy.mono, italic: state_copy.italic}]
                 },
-                &Token::TokPassageLink {ref display_name, ref passage_name} => {
+                &Token::TokPassageLink {ref display_name, ref passage_name, .. } => {
                     set_formatting = true;
                     vec![
                     ZOP::Call2NWithAddress{jump_to_label: "system_add_link".to_string(), address: passage_name.to_string()},
@@ -83,18 +83,18 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
                     ZOP::SetColor{foreground: 9, background: 2},
                     ]
                 },
-                &Token::TokAssign {ref var_name, ref op_name} => {
+                &Token::TokAssign {ref var_name, ref op_name, .. } => {
                     if op_name == "=" || op_name == "to" {
                         if t.childs.len() == 1 {
                             match t.childs[0].as_default().category {
-                                Token::TokInt {value} => {
+                                Token::TokInt {value, .. } => {
                                     if !manager.symbol_table.is_known_symbol(var_name) {
                                         manager.symbol_table.insert_new_symbol(&var_name, Type::Integer);
                                     }
                                     let symbol_id = manager.symbol_table.get_symbol_id(var_name);
                                     vec![ZOP::StoreU16{variable: symbol_id, value: value as u16}]
                                 },
-                                Token::TokBoolean {ref value} => {
+                                Token::TokBoolean {ref value, .. } => {
                                     if !manager.symbol_table.is_known_symbol(var_name) {
                                         manager.symbol_table.insert_new_symbol(&var_name, Type::Bool);
                                     }
@@ -109,7 +109,7 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
                         }
                     } else { vec![] }
                 },
-                &Token::TokIf => {
+                &Token::TokMacroIf { .. } => {
                     if t.childs.len() < 2 {
                         panic!("Unsupported if-expression!");
                     }
@@ -124,14 +124,14 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
 
                     // Check if first token is variable
                     let var_name = match pseudo_node.childs[0].as_default().category {
-                        Token::TokVariable {ref name} => name,
+                        Token::TokVariable {ref name, .. } => name,
                         _ =>  panic!("Unsupported if-expression!")
                     };
 
                     if pseudo_node.childs.len() > 1 {
                         // Check if second token is compare operator
                         match pseudo_node.childs[1].as_default().category {
-                            Token::TokCompOp {ref op_name} => {
+                            Token::TokCompOp {ref op_name, .. } => {
                                 match &*(*op_name) {
                                     "==" | "is" => {} ,
                                     _ => panic!("Unsupported Compare Operator!")
@@ -141,10 +141,10 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
 
                         // Check if third token is number
                         compare = match pseudo_node.childs[2].as_default().category {
-                            Token::TokInt {ref value} => {
+                            Token::TokInt {ref value, .. } => {
                                 *value as u8
                             },
-                            Token::TokBoolean {ref value} => {
+                            Token::TokBoolean {ref value, .. } => {
                                 boolstr_to_u8(&*value)
                             }, _ => panic!("Unsupported assign value!") 
                         };
@@ -172,7 +172,7 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
                     code.push(ZOP::Label{name: after_if_label});
                     code
                 },
-                &Token::TokElse => {
+                &Token::TokMacroElse { .. } => {
                     let mut code: Vec<ZOP> = vec![];
                     for child in &t.childs {
                         for instr in gen_zcode(child, out, manager) {
@@ -181,11 +181,11 @@ fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut zfile::Zfile, mut manager: &mu
                     }
                     code
                 },
-                &Token::TokEndIf => {
+                &Token::TokMacroEndIf { .. } => {
                     let after_else_label = format!("after_else_{}", manager.ids_if.pop_id());
                     vec![ZOP::Label{name: after_else_label}]
                 },
-                &Token::TokMacroVar {ref var_name} => {
+                &Token::TokMacroContentVar {ref var_name, .. } => {
                     let var_id = manager.symbol_table.get_symbol_id(&*var_name);
                     match manager.symbol_table.get_symbol_type(&*var_name) {
                         Type::Integer => {
@@ -282,7 +282,7 @@ impl AST {
      /// goes one lvl up and adds and child
     pub fn up_child(&mut self, token: Token, is_in_passage: bool) {
         match token {
-            Token::TokEndIf => {
+            Token::TokMacroEndIf { .. } => {
                 if is_in_passage == false {
                     self.up();
                     self.add_child(token);
@@ -303,7 +303,7 @@ impl AST {
     pub fn up_child_down(&mut self, token: Token) {
         
         match token {
-            Token::TokElse => {
+            Token::TokMacroElse { .. } => {
                 self.is_in_else += 1;
             },
             _ => {

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -110,6 +110,76 @@ pub enum Token {
     TokPseudo,
 }
 
+pub trait InputFileLocation {
+    fn location(&self) -> (u64, u64);
+}
+
+impl InputFileLocation for Token {
+    fn location(&self) -> (u64, u64) {
+        match self {
+            &TokPassage{location, ..} |
+            &TokTagStart{location} |
+            &TokTagEnd{location} |
+            &TokVarSetStart{location} |
+            &TokVarSetEnd{location} |
+            &TokPassageLink{location, ..} |
+            &TokTag{location, ..} |
+            &TokText{location, ..} |
+            &TokFormatBoldStart{location} |
+            &TokFormatBoldEnd{location} |
+            &TokFormatItalicStart{location} |
+            &TokFormatItalicEnd{location} |
+            &TokFormatUnderStart {location} |
+            &TokFormatUnderEnd{location} |
+            &TokFormatStrikeStart{location} |
+            &TokFormatStrikeEnd{location} |
+            &TokFormatSubStart{location} |
+            &TokFormatSubEnd{location} |
+            &TokFormatSupStart{location} |
+            &TokFormatSupEnd{location} |
+            &TokFormatMonoStart{location} |
+            &TokFormatMonoEnd{location} |
+            &TokFormatBulList{location} |
+            &TokFormatNumbList{location} |
+            &TokFormatIndentBlock{location} |
+            &TokFormatHorizontalLine{location} |
+            &TokFormatHeading{location, ..} |
+            &TokMacroStart{location} |
+            &TokMacroEnd{location} |
+            &TokMacroContentVar{location, ..} |
+            &TokMacroContentPassageName{location, ..} |
+            &TokMacroSet{location} |
+            &TokMacroIf{location} |
+            &TokMacroElse{location} |
+            &TokMacroEndIf{location} |
+            &TokMacroPrint{location} |
+            &TokMacroDisplay{location} |
+            &TokMacroSilently{location} |
+            &TokMacroEndSilently{location} |
+            &TokParenOpen{location} |
+            &TokParenClose{location} |
+            &TokVariable{location, ..} |
+            &TokInt{location, ..} |
+            &TokFloat{location, ..} |
+            &TokString{location, ..} |
+            &TokBoolean{location, ..} |
+            &TokFunction{location, ..} |
+            &TokColon{location} |
+            &TokArgsEnd{location} |
+            &TokArrayStart{location} |
+            &TokArrayEnd{location} |
+            &TokAssign{location, ..} |
+            &TokNumOp{location, ..} |
+            &TokCompOp{location, ..} |
+            &TokLogOp{location, ..} |
+            &TokSemiColon{location} |
+            &TokNewLine{location}
+                => location,
+            &TokPseudo => (0, 0)
+        }
+    }
+}
+
 rustlex! TweeLexer {
     // Properties
     property new_line:bool = true;

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -112,12 +112,8 @@ pub enum Token {
     TokPseudo,
 }
 
-pub trait InputFileLocation {
-    fn location(&self) -> (u64, u64);
-}
-
-impl InputFileLocation for Token {
-    fn location(&self) -> (u64, u64) {
+impl Token {
+    pub fn location(&self) -> (u64, u64) {
         match self {
             &TokPassage{location, ..} |
             &TokTagStart{location} |

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -526,7 +526,7 @@ rustlex! TweeLexer {
                 },
                 "endsilently" => {
                     lexer.MACRO_CONTENT();
-                    Some(TokMacroSilently {location: lexer.yylloc()} )
+                    Some(TokMacroEndSilently {location: lexer.yylloc()} )
                 },
                 _ => {
                     lexer.MACRO_CONTENT();

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -10,6 +10,7 @@ use frontend::ast;
 use frontend::parsetree::{PNode};
 use self::NonTerminalType::*;
 use frontend::lexer::Token::*;
+use frontend::lexer::InputFileLocation;
 
 pub fn parse_tokens(tokens: Vec<Token>) -> ast::AST {
     let mut parser: Parser = Parser::new(tokens);
@@ -436,11 +437,10 @@ impl Parser {
 
                     // ast
                     self.ast.add_child(tok.clone());
-                }
-
-                
-                _ => {
-                    panic!("not supported grammar: {:?}", state_first);
+                },
+                (_, tok) => {
+                    let (line, character) = tok.location();
+                    panic!("Unexpected token at {}:{}", line, character);
                 }
             }
 

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -10,7 +10,6 @@ use frontend::ast;
 use frontend::parsetree::{PNode};
 use self::NonTerminalType::*;
 use frontend::lexer::Token::*;
-use frontend::lexer::InputFileLocation;
 use config::Config;
 
 pub fn parse_tokens(cfg: &Config, tokens: Vec<Token>) -> ast::AST {

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -127,9 +127,9 @@ impl Parser {
                     // ast
                     self.ast.add_child(tok.clone());
                 },
-                (PassageContent, &TokFormatBoldStart) | 
-                (PassageContent, &TokFormatItalicStart) |
-                (PassageContent, &TokFormatMonoStart) => {
+                (PassageContent, &TokFormatBoldStart   { .. }) | 
+                (PassageContent, &TokFormatItalicStart { .. }) |
+                (PassageContent, &TokFormatMonoStart   { .. }) => {
                     new_nodes.push(PNode::new_non_terminal(Formating));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
                 },
@@ -137,32 +137,32 @@ impl Parser {
                     new_nodes.push(PNode::new_non_terminal(Link));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
                 },
-                (PassageContent, &TokNewLine) => {
-                    new_nodes.push(PNode::new_terminal(TokNewLine));
+                (PassageContent, tok @ &TokNewLine { .. }) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
 
                     // ast
-                    self.ast.add_child(TokNewLine);
+                    self.ast.add_child(tok.clone());
                 },
-                (PassageContent, &TokSet) |
-                (PassageContent, &TokIf) |
+                (PassageContent, &TokMacroSet { .. } ) |
+                (PassageContent, &TokMacroIf  { .. } ) |
                 (PassageContent, &TokVariable { .. } ) |
-                (PassageContent, &TokMacroVar { .. } ) |
-                (PassageContent, &TokMacroPassageName { .. } ) => {
+                (PassageContent, &TokMacroContentVar { .. } ) |
+                (PassageContent, &TokMacroContentPassageName { .. } ) => {
                     new_nodes.push(PNode::new_non_terminal(Macro));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
                 },
-                (PassageContent, &TokEndIf) => {
+                (PassageContent, tok @ &TokMacroEndIf { .. }) => {
                     // jump one ast-level higher
-                    debug!("pop TokEndIf Passage;");
+                    debug!("pop TokMacroEndIf Passage;");
 
-                    self.ast.up_child(TokEndIf, true);
+                    self.ast.up_child(tok.clone(), true);
                 },
-                (PassageContent, &TokFormatBoldEnd) => {
+                (PassageContent, &TokFormatBoldEnd { .. } ) => {
                     // jump one ast-level higher
                     self.ast.up();
                 },
-                (PassageContent, &TokFormatItalicEnd) => {
+                (PassageContent, &TokFormatItalicEnd { .. } ) => {
                     // jump one ast-level higher
                     self.ast.up();
                 },
@@ -171,44 +171,44 @@ impl Parser {
                 },
 
                 // Formating
-                (Formating, &TokFormatBoldStart) => {
+                (Formating, &TokFormatBoldStart { .. } ) => {
                     new_nodes.push(PNode::new_non_terminal(BoldFormatting));
                 },
-                (Formating, &TokFormatItalicStart) => {
+                (Formating, &TokFormatItalicStart { .. } ) => {
                     new_nodes.push(PNode::new_non_terminal(ItalicFormatting));
                 },
-                (Formating, &TokFormatMonoStart) => {
+                (Formating, &TokFormatMonoStart { .. } ) => {
                     new_nodes.push(PNode::new_non_terminal(MonoFormatting));
                 },
 
                 // BoldFormatting
-                (BoldFormatting, &TokFormatBoldStart) => {
-                    new_nodes.push(PNode::new_terminal(TokFormatBoldStart));
+                (BoldFormatting, tok @ &TokFormatBoldStart { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
-                    new_nodes.push(PNode::new_terminal(TokFormatBoldEnd));
+                    new_nodes.push(PNode::new_terminal(TokFormatBoldEnd {location: (0, 0)} ));
 
                     //ast
-                    self.ast.child_down(TokFormatBoldStart);
+                    self.ast.child_down(tok.clone());
                 },
 
                 // ItalicFormatting
-                (ItalicFormatting, &TokFormatItalicStart) => {
-                    new_nodes.push(PNode::new_terminal(TokFormatItalicStart));
+                (ItalicFormatting, tok @ &TokFormatItalicStart { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
-                    new_nodes.push(PNode::new_terminal(TokFormatItalicEnd));
+                    new_nodes.push(PNode::new_terminal(TokFormatItalicEnd {location: (0, 0)} ));
 
                     //ast
-                    self.ast.child_down(TokFormatItalicStart);
+                    self.ast.child_down(tok.clone());
                 },
 
                 // MonoFormatting
-                (MonoFormatting, &TokFormatMonoStart) => {
-                    new_nodes.push(PNode::new_terminal(TokFormatMonoStart));
+                (MonoFormatting, tok @ &TokFormatMonoStart { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(MonoContent));
-                    new_nodes.push(PNode::new_terminal(TokFormatMonoEnd));
+                    new_nodes.push(PNode::new_terminal(TokFormatMonoEnd {location: (0, 0)} ));
 
                     //ast
-                    self.ast.child_down(TokFormatMonoStart);
+                    self.ast.child_down(tok.clone());
                 },
 
                 // MonoContent
@@ -219,12 +219,12 @@ impl Parser {
                     // ast
                     self.ast.add_child(tok.clone());
                 },
-                (MonoContent, &TokNewLine) => {
-                    new_nodes.push(PNode::new_terminal(TokNewLine));
+                (MonoContent, tok @ &TokNewLine { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(MonoContent));
                 },
 
-                (MonoContent, &TokFormatMonoEnd) => {
+                (MonoContent, &TokFormatMonoEnd { .. } ) => {
                     // jump one ast-level higher
                     self.ast.up();
                 },
@@ -238,54 +238,54 @@ impl Parser {
                 },
 
                 // Macro
-                (Macro, &TokSet) => {
-                    new_nodes.push(PNode::new_terminal(TokSet));
+                (Macro, tok @ &TokMacroSet { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(ExpressionList));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
                 },
-                (Macro, &TokIf) => {
-                    new_nodes.push(PNode::new_terminal(TokIf));
+                (Macro, tok @ &TokMacroIf { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
                     new_nodes.push(PNode::new_non_terminal(ExpressionList));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
                     new_nodes.push(PNode::new_non_terminal(Macrof));
 
                     // ast
-                    self.ast.two_childs_down(TokIf, TokPseudo);
+                    self.ast.two_childs_down(tok.clone(), TokPseudo);
                 },
                 // means <<$var>>
-                (Macro, tok @ &TokMacroVar { .. }) => {
+                (Macro, tok @ &TokMacroContentVar { .. }) => {
                     new_nodes.push(PNode::new_terminal(tok.clone()));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
 
                     // ast
                     self.ast.add_child(tok.clone());
                 },
                 // means <<passagename>>
-                (Macro, tok @ &TokMacroPassageName { .. } ) => {
+                (Macro, tok @ &TokMacroContentPassageName { .. } ) => {
                     new_nodes.push(PNode::new_terminal(tok.clone()));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
 
                     // ast
                     self.ast.add_child(tok.clone());
                 },
                 // Macrof
-                (Macrof, &TokElse) => {
-                    new_nodes.push(PNode::new_terminal(TokElse));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                (Macrof, tok @ &TokMacroElse { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
                     new_nodes.push(PNode::new_non_terminal(PassageContent));
-                    new_nodes.push(PNode::new_terminal(TokEndIf));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                    new_nodes.push(PNode::new_terminal(TokMacroEndIf {location: (0, 0)} ));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
 
                     // ast
-                    self.ast.up_child_down(TokElse);
+                    self.ast.up_child_down(tok.clone());
                 },
-                (Macrof, &TokEndIf) => {
-                    new_nodes.push(PNode::new_terminal(TokEndIf));
-                    new_nodes.push(PNode::new_terminal(TokMacroEnd));
+                (Macrof, tok @ &TokMacroEndIf { .. } ) => {
+                    new_nodes.push(PNode::new_terminal(tok.clone()));
+                    new_nodes.push(PNode::new_terminal(TokMacroEnd {location: (0, 0)} ));
 
                     // ast
-                    self.ast.up_child(TokEndIf, false);
+                    self.ast.up_child(tok.clone(), false);
                 }
 
                 // ExpressionList
@@ -299,10 +299,9 @@ impl Parser {
                 },
 
                 // ExpressionListf
-                (ExpressionListf, &TokMacroEnd) => {
+                (ExpressionListf, &TokMacroEnd { .. } ) => {
                     debug!("pop TokMacroEnd");
                     self.ast.up();
-                    
                 },
                 (ExpressionListf, _) => {
                     // ExpressionListf -> ε


### PR DESCRIPTION
- Well, except TokPseudo.
- Also reformat some Token names to make more sense
- This is useful for #108

Noch andere nennenswerte Änderungen:
- TokIf, TokSet, … heißen jetzt TokMacroIf, TokMacroSet
- TokMacroDisplayName usw haben jetzt TokMacroContent als Prefix, um sie von den wirklichen Macros zu unterscheiden
- TokBracketStart/End heißen jetzt TokParenStart/End. Brackets sind die eckigen Klammern, Paranthesis die runden.
