### PR TITLE
simplify the if-else problem.

### DIFF
--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -283,7 +283,7 @@ impl AST {
         self.add_child(token);
     }
 
-    /// goeas one lvl up, adds an child and goes one lvl down
+    /// goes one lvl up, adds an child and goes one lvl down
     pub fn up_child_down(&mut self, token: Token) {
         self.up();
         self.child_down(token);

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -18,7 +18,6 @@ enum Type{
 pub struct AST {
     passages: Vec<ASTNode>,
     path: Vec<usize>,
-    is_in_else: u8
 }
 
  /// add zcode based on tokens
@@ -233,7 +232,6 @@ impl AST {
         AST {
             passages: Vec::new(),
             path: Vec::new(),
-            is_in_else: 0
         }
     }
 
@@ -280,44 +278,17 @@ impl AST {
     }
 
      /// goes one lvl up and adds and child
-    pub fn up_child(&mut self, token: Token, is_in_passage: bool) {
-        match token {
-            Token::TokEndIf => {
-                if is_in_passage == false {
-                    self.up();
-                    self.add_child(token);
-                } else if self.is_in_else > 0 {
-                    self.is_in_else -= 1;
-                    self.up();
-                    self.add_child(token);
-                }
-                
-            },
-            _ => {
-                panic!{"no supported"}
-            }
-        }
+    pub fn up_child(&mut self, token: Token) {
+        self.up();
+        self.add_child(token);
     }
 
     /// goeas one lvl up, adds an child and goes one lvl down
     pub fn up_child_down(&mut self, token: Token) {
-        
-        match token {
-            Token::TokElse => {
-                self.is_in_else += 1;
-            },
-            _ => {
-                panic!{"no supported"}
-            }
-        }
-
         self.up();
         self.child_down(token);
     }
 
-
-
-    
 
     /// convert ast to zcode
     pub fn to_zcode(& self, out: &mut zfile::Zfile) {

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -156,7 +156,7 @@ impl Parser {
                     // jump one ast-level higher
                     debug!("pop TokEndIf Passage;");
 
-                    self.ast.up_child(TokEndIf, true);
+                    self.ast.up_child(TokEndIf);
                 },
                 (PassageContent, &TokFormatBoldEnd) => {
                     // jump one ast-level higher
@@ -285,7 +285,7 @@ impl Parser {
                     new_nodes.push(PNode::new_terminal(TokMacroEnd));
 
                     // ast
-                    self.ast.up_child(TokEndIf, false);
+                    //self.ast.up_child(TokEndIf);
                 }
 
                 // ExpressionList


### PR DESCRIPTION
irina hat angemerkt, dass der if-else-kram eigentlich nicht so kompliziert sein sollte wie wir ihn machen.
ich hab es mir deshalb nochmal angeschaut und vermutlich kann es wirklich vereinfacht werden.
deshalb sind ein paar sachen rausgefallen.

da mich das selber aber alles sehr verwirrt hat und es nun auch spät ist, bitte überprüft **unbedingt** nochmal ob das so funktioniert.

meine vermutung warum das so implemetiert wurde:
früher hing mal der inhalt des if's unter einem pseudoknoten. dadurch musste unterschieden werden ob nun ein if oder ein else endet.
nun hängt aber die eigentliche expression unter einem pseudoknoten. deshalb geht es nach einem if als auch nach einem else immer eine ebene höher im baum.
