### PR TITLE
Pipe Config through Frontend

### DIFF
--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -19,6 +19,7 @@ pub fn generate_zcode<W: Write>(cfg: &Config, ast: ast::AST, output: &mut W) {
     };
 }
 
+#[allow(dead_code)]
 struct Codegen<'a> {
     cfg: &'a Config,
     ast: ast::AST,

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -3,10 +3,11 @@
 use std::error::Error;
 use std::io::Write;
 use frontend::ast;
+use config::Config;
 use super::super::backend::zcode::zfile;
 
-pub fn generate_zcode<W: Write>(ast: ast::AST, output: &mut W) {
-    let mut codegenerator = Codegen::new(ast);
+pub fn generate_zcode<W: Write>(cfg: &Config, ast: ast::AST, output: &mut W) {
+    let mut codegenerator = Codegen::new(cfg, ast);
     codegenerator.start_codegen();
     match output.write_all(&(*codegenerator.zfile_bytes())) {
         Err(why) => {
@@ -18,14 +19,16 @@ pub fn generate_zcode<W: Write>(ast: ast::AST, output: &mut W) {
     };
 }
 
-struct Codegen {
+struct Codegen<'a> {
+    cfg: &'a Config,
     ast: ast::AST,
     zfile: zfile::Zfile
 }
 
-impl Codegen {
-    pub fn new(ast: ast::AST) -> Codegen {
+impl<'a> Codegen<'a> {
+    pub fn new(cfg: &Config, ast: ast::AST) -> Codegen {
         Codegen {
+            cfg: cfg,
             ast: ast,
             zfile: zfile::Zfile::new()
         }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -9,6 +9,7 @@ pub struct ScanState {
     skip_next: bool,
 }
 
+#[allow(unused_variables)]
 pub fn lex<'a, R: Read>(cfg: &Config, input: &'a mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&'a mut R>>, Token>, ScanState, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
 
     info!("Nicht in Tokens verarbeitete Zeichen: ");

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -1,5 +1,6 @@
 use std::io::{BufReader, Read};
 use utils::extensions::{Peeking, PeekingExt, FilteringScan, FilteringScanExt};
+use config::Config;
 
 use self::Token::*;
 
@@ -8,7 +9,7 @@ pub struct ScanState {
     skip_next: bool,
 }
 
-pub fn lex<R: Read>(input: &mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&mut R>>, Token>, ScanState, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
+pub fn lex<'a, R: Read>(cfg: &Config, input: &'a mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&'a mut R>>, Token>, ScanState, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
 
     info!("Nicht in Tokens verarbeitete Zeichen: ");
 
@@ -608,12 +609,14 @@ rustlex! TweeLexer {
 mod tests {
 	use std::io::Cursor;
 
+    use config;
 	use super::*;
 	use super::Token::*;
 
 	fn test_lex(input: &str) -> Vec<Token> {
+	    let cfg = config::default_config();
 		let mut cursor: Cursor<Vec<u8>> = Cursor::new(input.to_string().into_bytes());
-		lex(&mut cursor).collect()
+		lex(&cfg, &mut cursor).collect()
 	}
 
 	#[test]

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -10,9 +10,10 @@ use frontend::ast;
 use frontend::parsetree::{PNode};
 use self::NonTerminalType::*;
 use frontend::lexer::Token::*;
+use config::Config;
 
-pub fn parse_tokens(tokens: Vec<Token>) -> ast::AST {
-    let mut parser: Parser = Parser::new(tokens);
+pub fn parse_tokens(cfg: &Config, tokens: Vec<Token>) -> ast::AST {
+    let mut parser: Parser = Parser::new(cfg, tokens);
     parser.parsing();
     parser.ast
 }
@@ -56,16 +57,18 @@ pub enum NonTerminalType {
 //==============================
 // parser
 
-struct Parser {
+struct Parser<'a> {
+    cfg: &'a Config,
     ast: ast::AST,
     stack: Vec<PNode>,
     tokens: Vec<Token>,
     lookahead: usize
 }
 
-impl Parser {
-    pub fn new(tokens: Vec<Token>) -> Parser {
+impl<'a> Parser<'a> {
+    pub fn new(cfg: &Config, tokens: Vec<Token>) -> Parser {
         Parser {
+            cfg: cfg,
             ast: ast::AST::new(),
             stack: Vec::new(),
             tokens: tokens,

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -57,6 +57,7 @@ pub enum NonTerminalType {
 //==============================
 // parser
 
+#[allow(dead_code)]
 struct Parser<'a> {
     cfg: &'a Config,
     ast: ast::AST,

--- a/src/zwreec/frontend/screener.rs
+++ b/src/zwreec/frontend/screener.rs
@@ -10,6 +10,7 @@ struct ScanState {
     skip_next: bool,
 }
 
+#[allow(unused_variables)]
 pub fn screen<R: Read>(cfg: &Config, input: &mut R) -> Cursor<Vec<u8>> {
 
     let mut content = String::new();

--- a/src/zwreec/frontend/screener.rs
+++ b/src/zwreec/frontend/screener.rs
@@ -1,6 +1,7 @@
 use std::io::{Cursor, Read};
 use std::error::Error;
 use utils::extensions::{PeekingExt, FilteringScanExt};
+use config::Config;
 
 // TODO: do not remove if in passage name, monospace etc.
 
@@ -9,7 +10,7 @@ struct ScanState {
     skip_next: bool,
 }
 
-pub fn screen<R: Read>(input: &mut R) -> Cursor<Vec<u8>> {
+pub fn screen<R: Read>(cfg: &Config, input: &mut R) -> Cursor<Vec<u8>> {
 
     let mut content = String::new();
     match input.read_to_string(&mut content) {

--- a/src/zwreec/lib.rs
+++ b/src/zwreec/lib.rs
@@ -22,19 +22,19 @@ use std::io::{Read,Write};
 #[allow(unused_variables)]
 pub fn compile<R: Read, W: Write>(cfg: Config, input: &mut R, output: &mut W) {
     //screen
-    let mut clean_input = frontend::screener::screen(input);
+    let mut clean_input = frontend::screener::screen(&cfg, input);
 
     // tokenize
-    let tokens = frontend::lexer::lex(&mut clean_input);
+    let tokens = frontend::lexer::lex(&cfg, &mut clean_input);
 
     // parse tokens and create ast
-    let ast = frontend::parser::parse_tokens(tokens.inspect(|ref token| {
+    let ast = frontend::parser::parse_tokens(&cfg, tokens.inspect(|ref token| {
         debug!("{:?}", token);
     }).collect()); //use collect until we work on iterators directly
     ast.print();
 
     // create code
-    codegen::generate_zcode(ast, output);
+    codegen::generate_zcode(&cfg, ast, output);
 }
 
 #[allow(unused_variables)]


### PR DESCRIPTION
Adds the config as a argument to most frontend calls. For Parser and Codegen, the Config is added to the struct to be easily available.

Note: The config is still not used.
