### PR TITLE
Added Better Errors for Lexer and Parser

### DIFF
--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -1,8 +1,11 @@
 use std::io::{BufReader, Read};
+use utils::error::Error;
 use utils::extensions::{Peeking, PeekingExt, FilteringScan, FilteringScanExt};
 use config::Config;
 
 use self::Token::*;
+
+pub struct LexerError;
 
 pub struct ScanState {
     current_text: String,

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -1,5 +1,4 @@
 use std::io::{BufReader, Read};
-use utils::error::Error;
 use utils::extensions::{Peeking, PeekingExt, FilteringScan, FilteringScanExt};
 use config::Config;
 

--- a/src/zwreec/utils/error.rs
+++ b/src/zwreec/utils/error.rs
@@ -1,0 +1,30 @@
+use frontend::lexer::LexerError;
+use frontend::parser::ParserError;
+
+trait Error {
+    fn raise(self) -> ! {
+        self.log();
+        panic!();
+    }
+    fn log(self);
+}
+
+impl Error for LexerError {
+    fn log(self) {
+        error!("[!!!] Critical Lexer Error [!!!]");
+    }
+}
+
+impl Error for ParserError {
+    fn log(self) {
+        error!("[!!!] Critical Parser Error [!!!]");
+        match self {
+            TokenDoNotMatch(token, stack) =>
+                match token {
+                    Some(token) => error!("Stack Token does not match. Token:{:?} Stack:{:?}", token, stack),
+                    None => error!("No Tokens left, but Terminal is left on Stack. Token:{:?}", stack),
+                },
+            StackIsEmpty(token) => error!("Tokens left but Stack is empty. Token:{:?}", token),
+        }
+    }
+}

--- a/src/zwreec/utils/error.rs
+++ b/src/zwreec/utils/error.rs
@@ -1,30 +1,32 @@
 use frontend::lexer::LexerError;
 use frontend::parser::ParserError;
 
-trait Error {
-    fn raise(self) -> ! {
+pub trait Error {
+    fn raise(&self) -> ! {
         self.log();
         panic!();
     }
-    fn log(self);
+    fn log(&self);
 }
 
 impl Error for LexerError {
-    fn log(self) {
+    fn log(&self) {
         error!("[!!!] Critical Lexer Error [!!!]");
     }
 }
 
 impl Error for ParserError {
-    fn log(self) {
+    fn log(&self) {
         error!("[!!!] Critical Parser Error [!!!]");
         match self {
-            TokenDoNotMatch(token, stack) =>
+            &ParserError::TokenDoNotMatch{ref token, ref stack} =>
                 match token {
-                    Some(token) => error!("Stack Token does not match. Token:{:?} Stack:{:?}", token, stack),
-                    None => error!("No Tokens left, but Terminal is left on Stack. Token:{:?}", stack),
+                    &Some(ref token) => error!("Stack Token does not match. Token:{:?} Stack:{:?}", token, stack),
+                    &None => error!("No Tokens left, but Terminal is left on Stack. Token:{:?}", stack),
                 },
-            StackIsEmpty(token) => error!("Tokens left but Stack is empty. Token:{:?}", token),
+            &ParserError::StackIsEmpty{ref token} => error!("Tokens left but Stack is empty. Token:{:?}", token),
+            &ParserError::NoProjection{ref token, ref stack} => error!("No Projection found for Token:{:?} and NonTerminal:{:?}", token, stack),
+            &ParserError::NonTerminalEnd{ref stack} => error!("NonTerminal:{:?} is no allowed End", stack),
         }
     }
 }

--- a/src/zwreec/utils/mod.rs
+++ b/src/zwreec/utils/mod.rs
@@ -1,2 +1,3 @@
 pub mod file;
 pub mod extensions;
+pub mod error;


### PR DESCRIPTION
Diese Request ist zum Diskutieren.

Finn hatte sich über die panics beschwert, also hier ne Idee, wie wir an einer Stelle das Logging machen und das Programm killen können via Panic und das ganzen in Code schöner aussieht und einfach sich erweitern lässt.
Keine Ahnung wie Rustlex Fehler wirft, daher macht das ganze erstmal nix... Der Parser hingegen behandelt ein paar (alle?) Fälle.

Kommentare?
