### PR TITLE
Zeichenketten werden hinter den Programmcode ausgelagert, Unterstützung für UTF16-Strings

### DIFF
--- a/src/zwreec/backend/zcode/mod.rs
+++ b/src/zwreec/backend/zcode/mod.rs
@@ -6,7 +6,7 @@ pub mod zfile;
 pub mod ztext;
 pub mod op;
 
-use self::zfile::{Zfile, Operand, Variable};
+use self::zfile::{Zfile, Operand, Variable, ZOP};
 
 use std::error::Error;
 use std::io::Write;
@@ -19,15 +19,24 @@ pub fn temp_create_zcode_example<W: Write>(output: &mut W) {
     let mut zfile: Zfile = zfile::Zfile::new();
 
     zfile.start();
-    // zfile.op_call_1n("Start");
-    zfile.routine("Start", 0);
-    zfile.gen_print_ops("Address of var 200: \n");
-    op::op_store_var(&Variable::new(200), &Operand::new_large_const(0x103));
-    // zfile.op_print_paddr(200);
-    op::op_newline();
-    op::op_newline();
-
-    zfile.op_quit();
+    let store_addr = zfile.object_addr + 2;
+    // code for debugging purposes and can be changed as wanted
+    zfile.emit(vec![
+        ZOP::Routine{name: "Start".to_string(), count_variables: 1},
+        ZOP::PrintOps{text: "Content at memory pointed by variable (expected 8729): \n".to_string()},
+        ZOP::StoreVariable{variable: Variable::new(200), value: Operand::new_large_const(0x2219)},
+        ZOP::StoreW{array_address: Operand::new_large_const(store_addr as i16), index: Variable::new(1), variable: Variable::new(200)},  // index at var:1 is 0
+        ZOP::StoreVariable{variable: Variable::new(200), value: Operand::new_large_const(store_addr as i16)},
+        ZOP::LoadW{array_address: Operand::new_var(200), index: Variable::new(1), variable: Variable::new(190)},
+        ZOP::Newline,
+        ZOP::PrintNumVar{variable: Variable::new(190)},
+        ZOP::Newline,
+        ZOP::PrintUnicodeVar{var: Variable::new(190)}, // should output ∙
+        ZOP::Newline,
+        ZOP::PrintUnicode{c: '∙' as u16},
+        ZOP::Newline,
+        ZOP::Quit,
+        ]);
     zfile.end();
 
     match output.write_all(&(*zfile.data.bytes)) {


### PR DESCRIPTION
(ersetzt den alten PR)

Statt alle Zeichenketten direkt als Argument hinter den Print-Opcode zu schreiben, können diese nun (aktuell bei Länge > 3) in den Bereich des static/high-mem ausgelagert werden und über print_paddr bzw. einen Funktionsaufruf in die eigens geschriebene Print-Funktion für UTF16-Strings ausgegeben werden.
Manche Opcodes wurden in ihren Argumenten erweitert oder neue hinzugefügt.

Im Vergleich zum aktuellen master sollte keine Regression vorliegen, bitte nochmal das sichtbare Ergebnis von CurrentStatus.twee vergleichen.
