### PR TITLE
Option to not panic during lexical analysis

### DIFF
--- a/src/bin/zwreec.rs
+++ b/src/bin/zwreec.rs
@@ -37,7 +37,6 @@ fn short_options() -> getopts::Options {
     opts.optflag("q", "quiet", "be quiet");
     opts.optflagopt("l", "logfile", "specify log file (default zwreec.log)", "LOGFILE");
     opts.optopt("o", "", "name of the output file", "FILE");
-    opts.optflag("f", "force", "force opening of output file");
     opts.optflag("h", "help", "display this help and exit");
     opts.optflag("V", "version", "display version");
 
@@ -213,7 +212,7 @@ fn parse_output(matches: &getopts::Matches) -> Option<Box<Write>> {
         // Check if FILE exists and issue warning.
         if File::open(path).is_ok() {
             if !matches.opt_present("f") {
-                error!("Output file {} already exists. Use '-f' to overwrite!", 
+                error!("Output file {} already exists. Use '-o NAME' to use a different name or '-f' to overwrite!", 
                        path.display());
                 return None;
             } else {

--- a/src/zwreec/config/mod.rs
+++ b/src/zwreec/config/mod.rs
@@ -161,6 +161,8 @@ use std::vec::Vec;
 /// }
 /// ```
 pub struct Config {
+    /// Force compilation despite errors
+    pub force: bool,
     /// Add easter egg to compiler
     pub easter_egg: bool,
     /// Instruct compiler to run these test-cases
@@ -178,6 +180,7 @@ impl Config {
     /// ```
     pub fn default_config() -> Config {
         Config{
+            force: false,
             easter_egg: true,
             test_cases: Vec::new(),
         }
@@ -209,6 +212,10 @@ impl Config {
 
         if matches.opt_present("generate-sample-zcode") {
             cfg.test_cases.push(TestCase::ZcodeBackend);
+        }
+
+        if matches.opt_present("f") {
+            cfg.force = true;
         }
 
         // TODO: Find a way to make these two loops somewhat less.. repetitive
@@ -308,6 +315,7 @@ pub enum TestCase {
 /// As you can see, `options()` returns your own command line options, which are then conditionally
 /// expanded by using `zwreec_options()`.
 pub fn zwreec_options(mut opts: getopts::Options) -> getopts::Options {
+    opts.optflag("f", "force", "force opening of output file");
     opts.optmulti("F", "feature", "", "FEAT");
     opts.optmulti("N", "no-feature", "enable or disable a feature (can occur multiple times).
                         List of supported features (default):

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -81,10 +81,9 @@ pub fn lex<'a, R: Read>(cfg: &'a Config, input: &'a mut R) -> FilteringScan<Peek
 
                 match elem {
                     (TokError {location, message}, _) => {
-                        if state.cfg.force {
-                            error!("{}", message);
-                        } else {
-                            panic!("{}", message);
+                        error!("{}", message);
+                        if !state.cfg.force {
+                            panic!();
                         }
                         None
                     }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -37,7 +37,8 @@ pub struct LexerError;
 ///
 /// The `zwreec::utils::extensions` module defines a new iterator `FilteringScan`.
 /// This struct stores the state for this iterator.
-pub struct ScanState {
+pub struct ScanState<'a> {
+    cfg: &'a Config,
     current_text: String,
     current_text_location: (u64, u64),
     skip_next: bool,
@@ -62,10 +63,11 @@ pub struct ScanState {
 /// let tokens = zwreec::frontend::lexer::lex(&cfg, &mut input);
 /// ```
 #[allow(unused_variables)]
-pub fn lex<'a, R: Read>(cfg: &Config, input: &'a mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&'a mut R>>, Token>, ScanState, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
+pub fn lex<'a, R: Read>(cfg: &'a Config, input: &'a mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&'a mut R>>, Token>, ScanState<'a>, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
 
     TweeLexer::new(BufReader::new(input)).peeking().scan_filter(
         ScanState {
+            cfg: cfg,
             current_text: String::new(),
             current_text_location: (0, 0),
             skip_next: false,
@@ -78,6 +80,14 @@ pub fn lex<'a, R: Read>(cfg: &Config, input: &'a mut R) -> FilteringScan<Peeking
                 }
 
                 match elem {
+                    (TokError {location, message}, _) => {
+                        if state.cfg.force {
+                            error!("{}", message);
+                        } else {
+                            panic!("{}", message);
+                        }
+                        None
+                    }
                     (TokText {location, text}, Some(TokText{ .. })) => {
                         if state.current_text.len() == 0 {
                             state.current_text_location = location;
@@ -166,6 +176,7 @@ pub enum Token {
     TokSemiColon              {location: (u64, u64)},
     TokNewLine                {location: (u64, u64)},
     TokExpression,
+    TokError                  {location: (u64, u64), message: String},
 }
 
 impl Token {
@@ -228,7 +239,8 @@ impl Token {
             &TokCompOp{location, ..} |
             &TokLogOp{location, ..} |
             &TokSemiColon{location} |
-            &TokNewLine{location}
+            &TokNewLine{location} |
+            &TokError{location, ..}
                 => location,
             &TokExpression => (0, 0)
         }
@@ -297,6 +309,7 @@ impl PartialEq for Token {
             (&TokLogOp{..}, &TokLogOp{..}) => true,
             (&TokSemiColon{..}, &TokSemiColon{..}) => true,
             (&TokNewLine{..}, &TokNewLine{..}) => true,
+            (&TokError{..}, &TokError{..}) => true,
             (&TokExpression, &TokExpression) => true,
             _ => false,
         }
@@ -683,7 +696,7 @@ rustlex! TweeLexer {
 
     MACRO_CONTENT {
 
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
+        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
 
         // Expression Stuff
         FUNCTION =>  |lexer:&mut TweeLexer<R>| {
@@ -741,23 +754,23 @@ rustlex! TweeLexer {
 
     MACRO_CONTENT_SHORT_PRINT {
 
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
+        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
 
         // Expression Stuff
-        FUNCTION =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        STRING =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        VAR_NAME =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        FLOAT =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        INT =>        |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        BOOL =>       |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        NUM_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        COMP_OP =>    |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        LOG_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        PAREN_OPEN => |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        PAREN_CLOSE =>|lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        SEMI_COLON => |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        ASSIGN =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
-        COLON =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_expression_panic(lexer.yystr(), lexer.yylloc()); None }
+        FUNCTION =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        STRING =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        VAR_NAME =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        FLOAT =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        INT =>        |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        BOOL =>       |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        NUM_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        COMP_OP =>    |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        LOG_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        PAREN_OPEN => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        PAREN_CLOSE =>|lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        SEMI_COLON => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        ASSIGN =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
+        COLON =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
         // Expression Stuff End
 
         NEWLINE =>  |_:&mut TweeLexer<R>| -> Option<Token> { None }
@@ -772,7 +785,7 @@ rustlex! TweeLexer {
 
     MACRO_CONTENT_SHORT_DISPLAY {
 
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { bad_argument_panic(lexer.yystr(), lexer.yylloc()); None }
+        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_argument(lexer.yystr(), lexer.yylloc())) }
 
         // Expression Stuff
         FUNCTION =>   |_:&mut TweeLexer<R>| -> Option<Token> { None }
@@ -892,16 +905,18 @@ fn unescape(s: String) -> String {
     unescaped
 }
 
-fn bad_expression_panic(s: String, loc: (u64,u64)) {
+fn bad_expression(s: String, loc: (u64,u64)) -> Token {
     let (line, symbol) = loc;
     //todo: error message should be "<<print>> bad expression: $test + bla"
-    panic!("<<print>> bad expression at {},{}: \"{}\"", line, symbol, s);
+    let m = format!("<<print>> bad expression at {},{}: \"{}\"", line, symbol, s);
+    TokError{location: loc, message: m}
 }
 
-fn bad_argument_panic(s: String, loc: (u64,u64)) {
+fn bad_argument(s: String, loc: (u64,u64)) -> Token {
     let (line, symbol) = loc;
     //todo: error message should be "<<Pop one>> bad argument: one"
-    panic!("<<display>> bad argument at {},{}: \"{}\"", line, symbol, s);
+    let m = format!("<<display>> bad argument at {},{}: \"{}\"", line, symbol, s);
+    TokError{location: loc, message: m}
 }
 
 


### PR DESCRIPTION
This PR introduces a new fake Token `TokError{location, message}` to record Errors that happened during the lexical analysis. The `FilteringScan` can then use this `TokError` to actually create an error or panic, depending on the config option `cfg.force`. This option is set by supplying `-f` on the command line. 

`bad_expression_panic()` and `bad_argument_panic()` have been rewritten to provide an `TokError` instead of directly panic-ing. 

To make the config available inside the `FilteringScan`, it has been added to the `ScanState` struct. The same approach could be used by the parser.

`LexerError` is still not used.

Some questions remain: Are there more errors, that are thrown by the lexer besides `bad_expression`/`bad_argument`? _Can_ there be more? Is there a way to pass (more) arguments to TweeLexer?

Regarding the error-handling inside the Parser: The Parser could also do some intelligent error handling, instead of throwing a panic. But to do that, it might need the ability to remove things from the AST. For example: An If-Statement without and Endif could be compiled by removing the entire If-Statement from the AST. But this does require additional logic. 

Depending of what was actually required by that Issue, this _might_ close #99.
