### PR TITLE
Fix für die Random Funktion

### DIFF
--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -310,7 +310,7 @@ pub fn function_random(arg_from: &Operand, arg_to: &Operand,
         operand2: arg_from.clone(), 
         save_variable: range_var.clone()
     });
-    code.push(ZOP::Sub{
+    code.push(ZOP::Add{
         operand1: Operand::new_var(range_var.id), 
         operand2: Operand::new_const(1), 
         save_variable: range_var.clone()
@@ -318,13 +318,18 @@ pub fn function_random(arg_from: &Operand, arg_to: &Operand,
 
     let var = Variable::new(temp_ids.pop().unwrap());
 
-    // get a random number between 0 and range
+    // get a random number between 1 and range
     code.push(ZOP::Random {range: Operand::new_var(range_var.id), variable: var.clone()} );
 
-    // add arg_from to range
+    // add (arg_from - 1) to range (because min. random is 1 not 0)
     code.push(ZOP::Add{
         operand1: Operand::new_var(var.id), 
         operand2: arg_from.clone(), 
+        save_variable: var.clone()
+    });
+     code.push(ZOP::Sub{
+        operand1: Operand::new_var(var.id), 
+        operand2: Operand::new_const(1), 
         save_variable: var.clone()
     });
     temp_ids.push(range_var.id);

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -66,6 +66,11 @@ fn random_test() {
 }
 
 #[test]
+fn random_expanded_test() {
+    test_compile(TESTFOLDER_PASS.to_string() + "RandomExpanded.twee");
+}
+
+#[test]
 fn if_else_test() {
     test_compile(TESTFOLDER_PASS.to_string() + "If-Else.twee");
 }

--- a/tests/integration/should-compile/RandomExpanded.twee
+++ b/tests/integration/should-compile/RandomExpanded.twee
@@ -1,0 +1,22 @@
+:: Start
+<<set $max to 0>>
+<<set $random_max to 100>>
+[[Start randomizing...|MaxRandom]]
+
+:: MaxRandom
+<<set $random to random(0,$random_max)>>
+Random is: <<$random>>
+<<if $random > $max>>
+<<set $max to $random>>
+<<endif>>
+Maximum is: <<$max>>
+<<if $max == $random_max>>
+Maximum ist reached.
+[[Start over...|Start]]
+<<else if $max > $random_max - 25>>
+Maximum is almost reached.
+[[Start over...|Start]]
+<<endif>>
+<<if $max < $random_max>>
+[[Next Random...|MaxRandom]]
+<<endif>>


### PR DESCRIPTION
Bis jetzt hat die Random Funktion nur Murks ausgegeben (random(0,2) gab z.B. nur 1 aus).
Jetzt gibt sie, wie von Twee spezifiziert, {0,1,2} aus.

Außerdem hab ich noch einen erweiterten Test hinzugefügt, der solange Zufallszahlen produziert, bis die maximale Zufallszahl erreicht wurde (Expressions und Links werden gleich auch ein bisschen mitgetestet).
