### PR TITLE
Feature/parentheses

### DIFF
--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -38,6 +38,7 @@ impl AST {
         for op in ops {
             ast.operation(op);
         }
+        // parse the expressions in the ast
         ast.parse_expressions();
 
         ast

--- a/src/zwreec/frontend/expressionparser.rs
+++ b/src/zwreec/frontend/expressionparser.rs
@@ -53,9 +53,35 @@ impl ExpressionParser {
 
                     self.oper_stack.push(tok.clone());
                 },
+                tok @ TokParenOpen { .. } => {
+                    self.oper_stack.push(tok.clone());
+                }
+                TokParenClose { .. } => {
+                    let length = self.oper_stack.len();
+
+                    for i in 0..length {
+                        let i_rev = length - i - 1;
+                        let token: Token = self.oper_stack.get(i_rev).unwrap().clone();
+                        //if is_ranking_not_higher(token, tok.clone()) {
+                        //    self.new_operator_node();
+                        //}
+                        match token {
+                            TokParenOpen { .. } => {
+                                break;
+                            }
+                            _ => {
+                                self.new_operator_node();
+                            }
+                        }
+                    }
+
+                    self.oper_stack.pop();
+
+                }
                 _ => ()
             }
         }
+        println!("LENGTH {:?}", self.expr_stack.len());
 
         // parse the last elements of the stack
         // to avoid endless loop we try max expr_stack.len()

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -412,7 +412,7 @@ rustlex! TweeLexer {
 
     let COMMENT = "/%" ([^"%"]*(("%")*[^"%/"])?)* ("%")* "%/";
 
-    let MACRO_CONTENT_FAIL = ([^"> 0123456789+-*/%="'\n''\t']*(">"[^"> "'\n''\t'])?)+;
+    let MACRO_CONTENT_FAIL = ([^"> 0123456789+-*/%=()"'\n''\t']*(">"[^"> "'\n''\t'])?)+;
 
     INITIAL {
         PASSAGE_START => |lexer:&mut TweeLexer<R>| -> Option<Token> {

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -392,7 +392,8 @@ impl<'a> Parser<'a> {
                 (ExpressionList, TokString   { .. } ) |
                 (ExpressionList, TokBoolean  { .. } ) |
                 (ExpressionList, TokAssign   { .. } ) |
-                (ExpressionList, TokFunction { .. } ) => {
+                (ExpressionList, TokFunction { .. } ) |
+                (ExpressionList, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(ExpressionListf));
                     stack.push(NonTerminal(Expression));
 
@@ -416,7 +417,8 @@ impl<'a> Parser<'a> {
                 (Expression, TokInt      { .. } ) |
                 (Expression, TokString   { .. } ) |
                 (Expression, TokBoolean  { .. } ) |
-                (Expression, TokFunction { .. } ) => {
+                (Expression, TokFunction { .. } ) |
+                (Expression, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(E));
 
                     None
@@ -432,7 +434,8 @@ impl<'a> Parser<'a> {
                 (E, TokInt      { .. } ) |
                 (E, TokString   { .. } ) |
                 (E, TokBoolean  { .. } ) |
-                (E, TokFunction { .. } ) => {
+                (E, TokFunction { .. } ) |
+                (E, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(E2));
                     stack.push(NonTerminal(T));
 
@@ -462,7 +465,8 @@ impl<'a> Parser<'a> {
                 (T, TokInt      { .. } ) |
                 (T, TokString   { .. } ) |
                 (T, TokBoolean  { .. } ) |
-                (T, TokFunction { .. } )=> {
+                (T, TokFunction { .. } ) |
+                (T, TokParenOpen{ .. } )=> {
                     stack.push(NonTerminal(T2));
                     stack.push(NonTerminal(B));
 
@@ -490,7 +494,8 @@ impl<'a> Parser<'a> {
                 (B, TokInt      { .. } ) |
                 (B, TokString   { .. } ) |
                 (B, TokBoolean  { .. } ) |
-                (B, TokFunction { .. } ) => {
+                (B, TokFunction { .. } ) |
+                (B, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(B2));
                     stack.push(NonTerminal(F));
 
@@ -518,7 +523,8 @@ impl<'a> Parser<'a> {
                 (F, TokInt      { .. } ) |
                 (F, TokString   { .. } ) |
                 (F, TokBoolean  { .. } ) |
-                (F, TokFunction { .. } ) => {
+                (F, TokFunction { .. } ) |
+                (F, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(F2));
                     stack.push(NonTerminal(G));
 
@@ -546,7 +552,8 @@ impl<'a> Parser<'a> {
                 (G, TokInt      { .. } ) |
                 (G, TokString   { .. } ) |
                 (G, TokBoolean  { .. } ) |
-                (G, TokFunction { .. } ) => {
+                (G, TokFunction { .. } ) |
+                (G, TokParenOpen{ .. } ) => {
                     stack.push(NonTerminal(G2));
                     stack.push(NonTerminal(H));
 
@@ -569,8 +576,7 @@ impl<'a> Parser<'a> {
                 (G2, TokSemiColon  { .. } ) |
                 (G2, TokCompOp     { .. } ) |
                 (G2, TokArgsEnd    { .. } ) |
-                (G2, TokColon      { .. } ) |
-                (G2, TokParenClose { .. } ) => {
+                (G2, TokColon      { .. } ) => {
                     // G2 -> ε
                     None
                 },
@@ -584,7 +590,6 @@ impl<'a> Parser<'a> {
                 (G2, tok) => {
                     ParserError::NoProjection{token: tok, stack: G2}.raise()
                 }
-
 
                 // H
                 (H, TokInt     { .. } ) |
@@ -601,6 +606,13 @@ impl<'a> Parser<'a> {
                 },
                 (H, TokFunction { .. } ) => {
                     stack.push(NonTerminal(Function));
+
+                    None
+                },
+                (H, tok @ TokParenOpen { .. } ) => {
+                    stack.push(Terminal(TokParenClose{location: (0, 0)}));
+                    stack.push(NonTerminal(Expression));
+                    stack.push(Terminal(tok.clone()));
 
                     None
                 },


### PR DESCRIPTION
Klammerunterstützung für die Expression.
damit wird der richtige AST für z.b. Ausdrücke wie

```
<<print 2*(3*(4+2))>>
```

erstellt. Die Klammerunterstützung vom AST->Zcode ist ja schon im Master. Bis auf die unären operatoren wäre damit bei den Expressions alles fertig.

es ist zwar -meines achtens- alels ausführlich dokumentiert, aber es wäre wohl gut, wenn das irgendeine person in rust schöner macht...
