### PR TITLE
Feature/unary expressions (parser part)

### DIFF
--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -38,7 +38,7 @@ impl AST {
         for op in ops {
             ast.operation(op);
         }
-        //ast.parse_expressions();
+        ast.parse_expressions();
 
         ast
     }

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -38,7 +38,7 @@ impl AST {
         for op in ops {
             ast.operation(op);
         }
-        ast.parse_expressions();
+        //ast.parse_expressions();
 
         ast
     }

--- a/src/zwreec/frontend/expressionparser.rs
+++ b/src/zwreec/frontend/expressionparser.rs
@@ -24,7 +24,6 @@ impl ExpressionParser {
 
     /// parse the expression node and creates mutliple ast nodes
     fn parse_expressions(&mut self, node: &mut NodeDefault) {
-
         node.childs.reverse();
         while let Some(top) = node.childs.pop() {
             match top.category() {

--- a/src/zwreec/frontend/expressionparser.rs
+++ b/src/zwreec/frontend/expressionparser.rs
@@ -35,9 +35,10 @@ impl ExpressionParser {
                     let childs_copy = top.as_default().childs.to_vec();
                     self.expr_stack.push( ASTNode::Default(NodeDefault { category: tok.clone(), childs: childs_copy }) );
                 },
-                tok @ TokNumOp  { .. } |
-                tok @ TokCompOp { .. } |
-                tok @ TokLogOp  { .. } => {
+                tok @ TokNumOp      { .. } |
+                tok @ TokCompOp     { .. } |
+                tok @ TokLogOp      { .. } |
+                tok @ TokUnaryMinus { .. } => {
                     let length = self.oper_stack.len();
 
                     // cycle through the oper_stack stack backwards
@@ -68,9 +69,8 @@ impl ExpressionParser {
                     let mut ast_node = NodeDefault { category: tok.clone(), childs: childs_copy };
                     ExpressionParser::parse(&mut ast_node);
                     
-                    if ast_node.childs.len() == 1 {
-                        let temp = ast_node.childs.get(0).unwrap().clone();
-                        self.expr_stack.push(temp);
+                    if let Some(temp) = ast_node.childs.get(0) {
+                        self.expr_stack.push(temp.clone());
                     } else {
                         panic!{"no parsable sub-expression"}
                     }
@@ -78,11 +78,16 @@ impl ExpressionParser {
                 _ => ()
             }
         }
-
-        // parse the last elements of the stack
-        // to avoid endless loop we try max expr_stack.len()
+        // parse the last elements of the stacks
+        // to avoid endless loop we try max stack.len()
         for _ in 0..self.expr_stack.len() {
             if self.expr_stack.len() > 0 {
+                self.new_operator_node();
+            }
+        }
+        // multiple operators could be on the stack becouse if the unary ops
+        for _ in 0..self.oper_stack.len() {
+            if self.oper_stack.len() > 0 {
                 self.new_operator_node();
             }
         }
@@ -97,11 +102,39 @@ impl ExpressionParser {
     /// creates a node with an operator on top
     fn new_operator_node(&mut self) {
         if let Some(top_op) = self.oper_stack.pop() {
-            let e2: ASTNode = self.expr_stack.pop().unwrap();
-            let e1: ASTNode = self.expr_stack.pop().unwrap();
 
-            let new_node = ASTNode::Default(NodeDefault { category: top_op.clone(), childs: vec![e1, e2] });
-            self.expr_stack.push( new_node );
+            let is_unary: bool = match top_op.clone() {
+                TokLogOp { op_name: op, .. } => match &*op {
+                    "not" => true,
+                    _   => false
+                },
+                TokUnaryMinus { .. } => true,
+                _  => false
+            };
+
+            if self.expr_stack.len() > 0 {
+                let e2: ASTNode = match self.expr_stack.pop() {
+                    Some(tok) => tok,
+                    None      => panic!{"Not enough elements on the stack to create a node"}
+                };
+
+                let mut new_node: ASTNode;
+               
+                if is_unary {
+                    new_node = ASTNode::Default(NodeDefault { category: top_op.clone(), childs: vec![e2] });
+                } else {
+                    let e1: ASTNode = match self.expr_stack.pop() {
+                        Some(tok) => tok,
+                        None      => panic!{"Missing Node to create binary node"}
+                    };
+                    new_node = ASTNode::Default(NodeDefault { category: top_op.clone(), childs: vec![e1, e2] });
+                }
+
+                self.expr_stack.push( new_node );
+            } else {
+                // multiple unary operators in a row like "not not true"
+                self.oper_stack.push(top_op.clone());
+            }
         }
     }
 }
@@ -110,25 +143,35 @@ impl ExpressionParser {
 /// is more important then operator of token2
 /// the ranking is set in "operator_precedence"
 fn is_ranking_not_higher(token1: Token, token2: Token) -> bool {
-    let mut op1: String = "".to_string();
-    let mut op2: String = "".to_string();
-    match token1 {
-        TokNumOp  { op_name, .. } |
-        TokCompOp { op_name, .. } |
-        TokLogOp  { op_name, .. } => {
-            op1 = op_name.clone();
+    let op1: String = match token1 {
+        TokUnaryMinus{ .. } => "_".to_string(),
+        TokNumOp     { op_name, .. } |
+        TokCompOp    { op_name, .. } |
+        TokLogOp     { op_name, .. } => {
+            op_name.clone()
         },
-        _ => ()
-    }
-    match token2 {
-        TokNumOp  { op_name, .. } |
-        TokCompOp { op_name, .. } |
-        TokLogOp  { op_name, .. } => {
-            op2 = op_name.clone();
+        _ => panic!{"not allowed operator"}
+    };
+    let op2: String = match token2 {
+        TokUnaryMinus{ .. } => "_".to_string(),
+        TokNumOp     { op_name, .. } |
+        TokCompOp    { op_name, .. } |
+        TokLogOp     { op_name, .. } => {
+            op_name.clone()
         },
-        _ => ()
+        _ => panic!{"not allowed operator"}
+    };
+    
+
+    // special handling for the unary operators (two unary operators in a row)
+    //let op1_copy: &str = op1.as_slice();
+    if (op1 == "_" || op1 == "not") &&
+        operator_rank(op1.clone()) == operator_rank(op2.clone()) {
+        
+        return false
     }
 
+    // 
     if operator_rank(op1) >= operator_rank(op2) {
         return true
     }
@@ -145,7 +188,8 @@ fn operator_rank(op: String) -> u8 {
                             => 3,
         "+" | "-"           => 4,
         "*" | "/" | "%"     => 5,
-        "not"               => 6,
+        "_"                 => 6, //unary minus
+        "not"               => 7,
         _                   => panic!{"This operator is not implemented"}
     }
 }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -174,6 +174,7 @@ pub enum Token {
     TokLogOp                  {location: (u64, u64), op_name: String},
     TokSemiColon              {location: (u64, u64)},
     TokNewLine                {location: (u64, u64)},
+    TokUnaryMinus             {location: (u64, u64)},
     TokExpression,
     TokError                  {location: (u64, u64), message: String},
 }
@@ -239,6 +240,7 @@ impl Token {
             &TokLogOp{location, ..} |
             &TokSemiColon{location} |
             &TokNewLine{location} |
+            &TokUnaryMinus{location} |
             &TokError{location, ..}
                 => location,
             &TokExpression => (0, 0)
@@ -308,6 +310,7 @@ impl PartialEq for Token {
             (&TokLogOp{..}, &TokLogOp{..}) => true,
             (&TokSemiColon{..}, &TokSemiColon{..}) => true,
             (&TokNewLine{..}, &TokNewLine{..}) => true,
+            (&TokUnaryMinus{..}, &TokUnaryMinus{..}) => true,
             (&TokError{..}, &TokError{..}) => true,
             (&TokExpression, &TokExpression) => true,
             _ => false,

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -134,8 +134,7 @@ impl<'a> Parser<'a> {
             {
                 /// the predictive stack ll(1) parsing routine
                 fn parse(state: &mut ParseState, token: Option<Token>) -> (ParseResult, Option<ASTOperation>) {
-
-                     match token {
+                    match token {
                         Some(token) => match state.stack.pop() {
                             Some(Elem::NonTerminal(non_terminal)) => (ParseResult::Halt, (state.grammar_func)(non_terminal, Some(token), &mut state.stack)),
                             Some(Elem::Terminal(stack_token)) => {
@@ -398,6 +397,15 @@ impl<'a> Parser<'a> {
 
                     None
                 },
+                (ExpressionList, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(ExpressionListf));
+                        stack.push(NonTerminal(Expression));
+
+                        None
+                    }
+                    _ => None
+                },
 
                 // ExpressionListf
                 (ExpressionListf, TokMacroEnd { .. } ) => {
@@ -427,6 +435,15 @@ impl<'a> Parser<'a> {
                     None
                 },
 
+                (Expression, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(E));
+
+                        None
+                    }
+                    _ => None
+                },
+
                 // E
                 (E, TokVariable { .. } ) |
                 (E, TokInt      { .. } ) |
@@ -438,6 +455,15 @@ impl<'a> Parser<'a> {
 
                     //None
                     Some(ChildDown(TokExpression))
+                },
+                (E, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(E2));
+                        stack.push(NonTerminal(T));
+
+                        None
+                    }
+                    _ => None
                 },
 
                 // E2
@@ -468,6 +494,15 @@ impl<'a> Parser<'a> {
 
                     None
                 },
+                (T, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(T2));
+                        stack.push(NonTerminal(B));
+
+                        None
+                    }
+                    _ => None
+                },
 
                 // T2
                 (T2, TokLogOp { location, op_name: op }) => match &*op {
@@ -495,6 +530,15 @@ impl<'a> Parser<'a> {
                     stack.push(NonTerminal(F));
 
                     None
+                },
+                (B, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(B2));
+                        stack.push(NonTerminal(F));
+
+                        None
+                    }
+                    _ => None
                 },
 
                 // B2
@@ -524,6 +568,15 @@ impl<'a> Parser<'a> {
 
                     None
                 },
+                (F, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(F2));
+                        stack.push(NonTerminal(G));
+
+                        None
+                    }
+                    _ => None
+                },
 
                 // F2
                 (F2, TokNumOp { location, op_name: op }) =>  match &*op {
@@ -551,6 +604,15 @@ impl<'a> Parser<'a> {
                     stack.push(NonTerminal(H));
 
                     None
+                },
+                (G, TokNumOp { op_name: op, .. }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(G2));
+                        stack.push(NonTerminal(H));
+
+                        None
+                    }
+                    _ => None
                 },
 
                 // G2
@@ -587,6 +649,15 @@ impl<'a> Parser<'a> {
 
 
                 // H
+                (H, TokNumOp { location, op_name: op }) =>  match &*op {
+                    "-" => {
+                        stack.push(NonTerminal(H));
+                        stack.push(Terminal(TokNumOp{location: location.clone(), op_name: op.clone()}));
+
+                        Some(AddChild(TokNumOp{location: location, op_name: op}))
+                    }
+                    _ => None
+                },
                 (H, TokInt     { .. } ) |
                 (H, TokString  { .. } ) |
                 (H, TokBoolean { .. } ) => {

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -654,7 +654,7 @@ impl<'a> Parser<'a> {
                         stack.push(NonTerminal(H));
                         stack.push(Terminal(TokNumOp{location: location.clone(), op_name: op.clone()}));
 
-                        Some(AddChild(TokNumOp{location: location, op_name: op}))
+                        Some(AddChild(TokNumOp{location: location, op_name: "_".to_string()}))
                     }
                     _ => None
                 },


### PR DESCRIPTION
Nun werden unäre operatoren wie not und "-" im Parser richtig behandelt und der entsprechende AST erstellt.

um die Expressions endlich vollständig zu haben, fehlt nun nur noch der Teil in evaluate_expression.rs um die neuen Token "TokUnaryMinus" richtig zu behandeln. das einfachste wäre es bei jedem TokUnaryMinus das kind dieses knotens mit (-1) zu multiplizieren.

Dieser PR baut auf #173 (Feature/parentheses) auf.

Beispiel:

```
<<print 1*--(-2-3)>>
<<print not (not true and true)>>
```

![ast](https://cloud.githubusercontent.com/assets/1397415/8331726/1af4af6a-1a8a-11e5-86d7-6c6747135b59.png)
