### PR TITLE
Typinformation hängt an der Variable

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -4,8 +4,15 @@ pub use super::zbytes::Bytes;
 pub use super::ztext;
 pub use super::op;
 
+#[derive(Clone, PartialEq, Debug)]
+pub enum Type {
+    Bool,
+    Integer,
+    String,
+}
+
 #[derive(Debug,Clone)]
-pub struct Variable { pub id: u8 }
+pub struct Variable { pub id: u8, pub vartype: Type}
 #[derive(Debug,Clone)]
 pub struct Constant { pub value: u8 }
 #[derive(Debug,Clone)]
@@ -36,6 +43,10 @@ impl Operand {
         Operand::Var(Variable::new(id))
     }
 
+    pub fn new_var_string(id: u8) -> Operand {
+        Operand::Var(Variable::new_string(id))
+    }
+
     pub fn const_value(&self) -> i16 {
         match self {
             &Operand::Const(ref constant) => constant.value as i16,
@@ -54,7 +65,13 @@ impl Operand {
 
 impl Variable {
     pub fn new(id: u8) -> Variable {
-        Variable { id: id }
+        Variable { id: id, vartype: Type::Integer }
+    }
+    pub fn new_string(id: u8) -> Variable {
+        Variable { id: id, vartype: Type::String }
+    }
+    pub fn new_bool(id: u8) -> Variable {
+        Variable { id: id, vartype: Type::Bool }
     }
 }
 

--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -2,9 +2,8 @@
 //! to create and walk through the ast (abstract syntaxtree)
 
 use backend::zcode::zfile;
-use backend::zcode::zfile::{ZOP};
+use backend::zcode::zfile::{ZOP, Type};
 use frontend::codegen;
-use frontend::codegen::Type;
 use frontend::expressionparser;
 use frontend::lexer::Token;
 use frontend::lexer::Token::{TokMacroIf, TokMacroElseIf, TokExpression, TokPassage};

--- a/src/zwreec/frontend/evaluate_expression.rs
+++ b/src/zwreec/frontend/evaluate_expression.rs
@@ -155,7 +155,7 @@ fn eval_comp_op<'a>(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut 
     if count_constants(eval0, eval1) == 2 {
         return direct_eval_comp_op(eval0, eval1, op_name);
     }
-    let save_var = Variable { id: temp_ids.pop().unwrap() };
+    let save_var = Variable::new(temp_ids.pop().unwrap());
     let label = format!("expr_{}", manager.ids_expr.start_next());
     let const_true = Operand::new_const(1);
     let const_false = Operand::new_const(0);
@@ -256,7 +256,7 @@ fn eval_not<'a>(eval: &Operand, code: &mut Vec<ZOP>,
         let result: u8 = if val > 0 { 0 } else { 1 };
         return Operand::Const(Constant { value: result });
     }
-    let save_var = Variable { id: temp_ids.pop().unwrap() };
+    let save_var = Variable::new(temp_ids.pop().unwrap());
     let label = format!("expr_{}", manager.ids_expr.start_next());
     code.push(ZOP::StoreVariable{ variable: save_var.clone(), value: Operand::new_const(0)});
     code.push(ZOP::JG{operand1: eval.clone(), operand2: Operand::new_const(0), jump_to_label: label.to_string()});
@@ -307,7 +307,7 @@ fn determine_save_var(operand1: &Operand, operand2: &Operand, temp_ids: &mut Vec
             }
         }, _ => {}
     };
-    return Variable { id: temp_ids.pop().unwrap() };
+    return Variable::new(temp_ids.pop().unwrap());
 }
 
 fn count_constants(operand1: &Operand, operand2: &Operand) -> u8 {


### PR DESCRIPTION
Wird gebraucht. Löst auch das Iterieren durch die Symboltabelle ab.
