### PR TITLE
fixes #169

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -605,6 +605,9 @@ impl Zfile {
             ZOP::SetColor{foreground: 9, background: 2},
             ZOP::EraseWindow{value: -1},
             ZOP::Call1N{jump_to_label: "Start".to_string()},
+            ZOP::Label{name: "mainloop".to_string()},
+            ZOP::Call1N{jump_to_label: "system_check_links".to_string()},
+            ZOP::Jump{jump_to_label: "mainloop".to_string()},
         ]);
     }
 

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -83,7 +83,6 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
             }
 
             code.push(ZOP::Newline);
-            code.push(ZOP::Call1N{jump_to_label: "system_check_links".to_string()});
             code.push(ZOP::Ret{value: 0});
             code
         },


### PR DESCRIPTION
Die Passage-Funktion wird verlassen und eine mainloop ruft check_links auf.
