### PR TITLE
Bugfix/missing logical operators

### DIFF
--- a/src/zwreec/frontend/evaluate_expression.rs
+++ b/src/zwreec/frontend/evaluate_expression.rs
@@ -38,15 +38,15 @@ fn evaluate_expression_internal<'a>(node: &'a ASTNode, code: &mut Vec<ZOP>,
         },
         TokLogOp { ref op_name, .. } => {
             let eval0 = evaluate_expression_internal(&n.childs[0], code, temp_ids, manager, &mut out);
-            
+
             match &**op_name {
-                "and" | "or" => {
+                "and" | "&&" | "or" | "||" => {
                     let eval1 = evaluate_expression_internal(&n.childs[1], code, temp_ids, manager, &mut out);
                     eval_and_or(&eval0, &eval1, &**op_name, code, temp_ids)
                 },
-                "not" => {
+                "not" | "!" => {
                     eval_not(&eval0, code, temp_ids, manager)
-                }, 
+                },
                 _ => panic!("unhandled op")
             }
         },
@@ -154,7 +154,7 @@ fn direct_eval_num_op(eval0: &Operand, eval1: &Operand, op_name: &str) -> Operan
     }
 }
 
-fn eval_comp_op<'a>(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<ZOP>, 
+fn eval_comp_op<'a>(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<ZOP>,
         temp_ids: &mut Vec<u8>, mut manager: &mut CodeGenManager<'a>) -> Operand {
     if count_constants(eval0, eval1) == 2 {
         return direct_eval_comp_op(eval0, eval1, op_name);
@@ -223,7 +223,7 @@ fn direct_eval_comp_op(eval0: &Operand, eval1: &Operand, op_name: &str) -> Opera
     }
 }
 
-fn eval_and_or(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<ZOP>, 
+fn eval_and_or(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<ZOP>,
         temp_ids: &mut Vec<u8>) -> Operand {
     if count_constants(&eval0, &eval1) == 2 {
         let mut out_large = false;
@@ -231,7 +231,7 @@ fn eval_and_or(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<Z
         let val1 = eval1.const_value();
         match eval0 { &Operand::LargeConst(_) => {out_large = true; }, _ => {} };
         match eval1 { &Operand::LargeConst(_) => {out_large = true; }, _ => {} };
-        let result = if op_name == "or" {
+        let result = if op_name == "or" || op_name == "||" {
                 val0 | val1
             } else {
                 val0 & val1
@@ -242,9 +242,9 @@ fn eval_and_or(eval0: &Operand, eval1: &Operand, op_name: &str, code: &mut Vec<Z
             return Operand::Const(Constant { value: result as u8 })
         }
     }
-    
+
     let save_var = determine_save_var(eval0, eval1, temp_ids);
-    if op_name == "or" {
+    if op_name == "or" || op_name == "||" {
         code.push(ZOP::Or{operand1: eval0.clone(), operand2: eval1.clone(), save_variable: save_var.clone()});
     } else {
         code.push(ZOP::And{operand1: eval0.clone(), operand2: eval1.clone(), save_variable: save_var.clone()});
@@ -280,7 +280,7 @@ fn eval_unary_minus(eval: &Operand, code: &mut Vec<ZOP>, temp_ids: &mut Vec<u8>)
         }
     }
 
-    let save_var = match eval { 
+    let save_var = match eval {
         &Operand::Var(ref var) => {
             if CodeGenManager::is_temp_var(var) {
                 Variable::new(var.id)
@@ -296,7 +296,7 @@ fn eval_unary_minus(eval: &Operand, code: &mut Vec<ZOP>, temp_ids: &mut Vec<u8>)
 }
 
 fn free_var_if_both_temp (eval0: &Operand, eval1: &Operand, temp_ids: &mut Vec<u8>) {
-    match eval0 { 
+    match eval0 {
         &Operand::Var(ref var1) => {
             if CodeGenManager::is_temp_var(var1) {
                 match eval1 {

--- a/src/zwreec/frontend/expressionparser.rs
+++ b/src/zwreec/frontend/expressionparser.rs
@@ -60,7 +60,7 @@ impl ExpressionParser {
                 tok @ TokExpression => {
                     // more ugly code.
                     // an expression-node is a child of an expression, if there
-                    // where parentheses in the expression. but we don't want 
+                    // where parentheses in the expression. but we don't want
                     // them, so we parse the subexpression in the parentheses
 
                     // make a copy of the top-node. (becouse node is borrowed)
@@ -68,7 +68,7 @@ impl ExpressionParser {
                     let childs_copy = top.as_default().childs.to_vec();
                     let mut ast_node = NodeDefault { category: tok.clone(), childs: childs_copy };
                     ExpressionParser::parse(&mut ast_node);
-                    
+
                     if let Some(temp) = ast_node.childs.get(0) {
                         self.expr_stack.push(temp.clone());
                     } else {
@@ -106,7 +106,8 @@ impl ExpressionParser {
             let is_unary: bool = match top_op.clone() {
                 TokLogOp { op_name: op, .. } => match &*op {
                     "not" => true,
-                    _   => false
+                    "!"   => true,
+                    _     => false
                 },
                 TokUnaryMinus { .. } => true,
                 _  => false
@@ -119,7 +120,7 @@ impl ExpressionParser {
                 };
 
                 let mut new_node: ASTNode;
-               
+
                 if is_unary {
                     new_node = ASTNode::Default(NodeDefault { category: top_op.clone(), childs: vec![e2] });
                 } else {
@@ -161,17 +162,17 @@ fn is_ranking_not_higher(token1: Token, token2: Token) -> bool {
         },
         _ => panic!{"not allowed operator"}
     };
-    
+
 
     // special handling for the unary operators (two unary operators in a row)
     //let op1_copy: &str = op1.as_slice();
-    if (op1 == "_" || op1 == "not") &&
+    if (op1 == "_" || op1 == "not" || op1 == "!") &&
         operator_rank(op1.clone()) == operator_rank(op2.clone()) {
-        
+
         return false
     }
 
-    // 
+    //
     if operator_rank(op1) >= operator_rank(op2) {
         return true
     }
@@ -182,14 +183,13 @@ fn is_ranking_not_higher(token1: Token, token2: Token) -> bool {
 /// ranking of the operators
 fn operator_rank(op: String) -> u8 {
     match op.as_ref() {
-        "or"                => 1,
-        "and"               => 2,
+        "or" | "||"         => 1,
+        "and" | "&&"        => 2,
         "is" | "==" | "eq" | "neq" | ">" | "gt" | ">=" | "gte" | "<" | "lt" | "<=" | "lte"
                             => 3,
         "+" | "-"           => 4,
         "*" | "/" | "%"     => 5,
-        "_"                 => 6, //unary minus
-        "not"               => 7,
+        "_" | "not" | "!"   => 6, // _ is unary minus
         _                   => panic!{"This operator is not implemented"}
     }
 }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -412,8 +412,6 @@ rustlex! TweeLexer {
 
     let COMMENT = "/%" ([^"%"]*(("%")*[^"%/"])?)* ("%")* "%/";
 
-    let MACRO_CONTENT_FAIL = ([^"> 0123456789+-*/%=()!&|"'\n''\t']*(">"[^"> "'\n''\t'])?)+;
-
     INITIAL {
         PASSAGE_START => |lexer:&mut TweeLexer<R>| -> Option<Token> {
             lexer.PASSAGE();
@@ -695,8 +693,6 @@ rustlex! TweeLexer {
 
     MACRO_CONTENT {
 
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-
         // Expression Stuff
         FUNCTION =>  |lexer:&mut TweeLexer<R>| {
             let s =  lexer.yystr();
@@ -753,25 +749,6 @@ rustlex! TweeLexer {
 
     MACRO_CONTENT_SHORT_PRINT {
 
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-
-        // Expression Stuff
-        FUNCTION =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        STRING =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        VAR_NAME =>   |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        FLOAT =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        INT =>        |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        BOOL =>       |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        NUM_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        COMP_OP =>    |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        LOG_OP =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        PAREN_OPEN => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        PAREN_CLOSE =>|lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        SEMI_COLON => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        ASSIGN =>     |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        COLON =>      |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_expression(lexer.yystr(), lexer.yylloc())) }
-        // Expression Stuff End
-
         NEWLINE =>  |_:&mut TweeLexer<R>| -> Option<Token> { None }
 
         WHITESPACE =>  |_:&mut TweeLexer<R>| -> Option<Token> { None }
@@ -783,8 +760,6 @@ rustlex! TweeLexer {
     }
 
     MACRO_CONTENT_SHORT_DISPLAY {
-
-        MACRO_CONTENT_FAIL => |lexer:&mut TweeLexer<R>| -> Option<Token> { Some(bad_argument(lexer.yystr(), lexer.yylloc())) }
 
         // Expression Stuff
         FUNCTION =>   |_:&mut TweeLexer<R>| -> Option<Token> { None }
@@ -902,20 +877,6 @@ fn unescape(s: String) -> String {
     }
 
     unescaped
-}
-
-fn bad_expression(s: String, loc: (u64,u64)) -> Token {
-    let (line, symbol) = loc;
-    //todo: error message should be "<<print>> bad expression: $test + bla"
-    let m = format!("<<print>> bad expression at {},{}: \"{}\"", line, symbol, s);
-    TokError{location: loc, message: m}
-}
-
-fn bad_argument(s: String, loc: (u64,u64)) -> Token {
-    let (line, symbol) = loc;
-    //todo: error message should be "<<Pop one>> bad argument: one"
-    let m = format!("<<display>> bad argument at {},{}: \"{}\"", line, symbol, s);
-    TokError{location: loc, message: m}
 }
 
 

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -401,7 +401,7 @@ rustlex! TweeLexer {
     let SEMI_COLON = ';';
     let NUM_OP = ["+-*/%"];
     let COMP_OP = "is" | "==" | "eq" | "neq" | ">" | "gt" | ">=" | "gte" | "<" | "lt" | "<=" | "lte";
-    let LOG_OP = "and" | "or" | "not";
+    let LOG_OP = "and" | "&&" | "or" | "||" | "not" | "!";
 
     let LINK_OPEN = '[';
     let LINK_CLOSE = ']';
@@ -412,7 +412,7 @@ rustlex! TweeLexer {
 
     let COMMENT = "/%" ([^"%"]*(("%")*[^"%/"])?)* ("%")* "%/";
 
-    let MACRO_CONTENT_FAIL = ([^"> 0123456789+-*/%=()"'\n''\t']*(">"[^"> "'\n''\t'])?)+;
+    let MACRO_CONTENT_FAIL = ([^"> 0123456789+-*/%=()!&|"'\n''\t']*(">"[^"> "'\n''\t'])?)+;
 
     INITIAL {
         PASSAGE_START => |lexer:&mut TweeLexer<R>| -> Option<Token> {

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -418,7 +418,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (ExpressionList, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(ExpressionListf));
                         stack.push(NonTerminal(Expression));
 
@@ -465,7 +465,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (Expression, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(E));
 
                         None
@@ -496,7 +496,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (E, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(E2));
                         stack.push(NonTerminal(T));
 
@@ -507,7 +507,7 @@ impl<'a> Parser<'a> {
 
                 // E2
                 (E2, TokLogOp { location, op_name: op }) => match &*op {
-                    "or" => {
+                    "or" | "||" => {
                         stack.push(NonTerminal(E2));
                         stack.push(NonTerminal(T));
                         stack.push(Terminal(TokLogOp{location: location.clone(), op_name: op.clone()}));
@@ -544,7 +544,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (T, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(T2));
                         stack.push(NonTerminal(B));
 
@@ -555,7 +555,7 @@ impl<'a> Parser<'a> {
 
                 // T2
                 (T2, TokLogOp { location, op_name: op }) => match &*op {
-                    "and" => {
+                    "and" | "&&" => {
                         stack.push(NonTerminal(T2));
                         stack.push(NonTerminal(B));
                         stack.push(Terminal(TokLogOp{location: location.clone(), op_name: op.clone()}));
@@ -591,7 +591,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (B, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(B2));
                         stack.push(NonTerminal(F));
 
@@ -638,7 +638,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (F, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(F2));
                         stack.push(NonTerminal(G));
 
@@ -685,7 +685,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (G, TokLogOp { op_name: op, .. }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(G2));
                         stack.push(NonTerminal(H));
 
@@ -716,7 +716,7 @@ impl<'a> Parser<'a> {
                     None
                 },
                 (G2, TokLogOp { location, op_name: op }) => match &*op {
-                    "and" | "or" => {
+                    "and" | "&&" | "or" | "||" => {
                         // G2 -> ε =>
                         None
                     },
@@ -738,7 +738,7 @@ impl<'a> Parser<'a> {
                     _ => None
                 },
                 (H, TokLogOp { location, op_name: op }) =>  match &*op {
-                    "not" => {
+                    "not" | "!" => {
                         stack.push(NonTerminal(H));
                         stack.push(Terminal(TokLogOp{location: location.clone(), op_name: op.clone()}));
 


### PR DESCRIPTION
Neben den logischen Operatoren "not", "and" und "or" funktionieren nun auch "!", "&&" und "||". Die haben zuvor gefehlt.

Ich hab das Regex MACRO_CONTENT_FAIL entfernt, weil wir nun eine andere Fehlerbehandlung im Lexer haben. 
