### PR TITLE
Neues Flag, um die unicode-translation-table zu umgehen

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -159,6 +159,7 @@ pub struct Zfile {
     last_static_written: u16,
     pub heap_start: u16,
     pub force_unicode: bool,
+    pub easter_egg: bool,
 }
 
 #[derive(Debug, PartialEq, Clone)]
@@ -196,10 +197,10 @@ impl Zfile {
 
     /// creates a new zfile
     pub fn new() -> Zfile {
-        Zfile::new_with_options(false)
+        Zfile::new_with_options(false, false)
     }
 
-    pub fn new_with_options(force_unicode: bool) -> Zfile {
+    pub fn new_with_options(force_unicode: bool, easter_egg: bool) -> Zfile {
         Zfile {
             data: Bytes{bytes: Vec::new()},
             unicode_table: Vec::new(),
@@ -214,11 +215,12 @@ impl Zfile {
             last_static_written: 0x8000,
             heap_start: 0x800,
             force_unicode: force_unicode,
+            easter_egg: easter_egg,
         }
     }
 
     pub fn new_with_cfg(cfg: &Config) -> Zfile {
-        Zfile::new_with_options(cfg.force_unicode)
+        Zfile::new_with_options(cfg.force_unicode, cfg.easter_egg)
     }
 
     /// creates the header of a zfile
@@ -760,83 +762,90 @@ impl Zfile {
 
     /// easter-egg, with konami-code to start
     pub fn routine_check_more(&mut self) {
-        self.emit(vec![
-            ZOP::Routine{name: "system_check_more".to_string(), count_variables: 1},
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(129), jump_to_label: "system_check_more_ko_1".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_1".to_string()},
-        
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(130), jump_to_label: "system_check_more_ko_2".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_2".to_string()},
+        if self.easter_egg {
+            self.emit(vec![
+                ZOP::Routine{name: "system_check_more".to_string(), count_variables: 1},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(129), jump_to_label: "system_check_more_ko_1".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_1".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(130), jump_to_label: "system_check_more_ko_3".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_3".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(130), jump_to_label: "system_check_more_ko_2".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_2".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(131), jump_to_label: "system_check_more_ko_4".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_4".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(130), jump_to_label: "system_check_more_ko_3".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_3".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(132), jump_to_label: "system_check_more_ko_5".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_5".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(131), jump_to_label: "system_check_more_ko_4".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_4".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(131), jump_to_label: "system_check_more_ko_6".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_6".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(132), jump_to_label: "system_check_more_ko_5".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_5".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(132), jump_to_label: "system_check_more_ko_7".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_7".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(131), jump_to_label: "system_check_more_ko_6".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_6".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(98), jump_to_label: "system_check_more_ko_8".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_8".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(132), jump_to_label: "system_check_more_ko_7".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_7".to_string()},
 
-            ZOP::ReadChar{local_var_id: 0x01},
-            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(97), jump_to_label: "system_check_more_ko_9".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)},
-            ZOP::Label{name: "system_check_more_ko_9".to_string()},
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(98), jump_to_label: "system_check_more_ko_8".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_8".to_string()},
 
-            ZOP::Label{name: "system_check_more_timer_loop".to_string()},
-            ZOP::ReadCharTimer{local_var_id: 0x01, timer: 1, routine: "system_check_more_anim".to_string()},
-            ZOP::Jump{jump_to_label: "system_check_more_timer_loop".to_string()},
-            ZOP::Quit,
+                ZOP::ReadChar{local_var_id: 0x01},
+                ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(97), jump_to_label: "system_check_more_ko_9".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)},
+                ZOP::Label{name: "system_check_more_ko_9".to_string()},
 
-            ZOP::Routine{name: "system_check_more_anim".to_string(), count_variables: 5},
-            ZOP::EraseWindow{value: -1},
+                ZOP::Label{name: "system_check_more_timer_loop".to_string()},
+                ZOP::ReadCharTimer{local_var_id: 0x01, timer: 1, routine: "system_check_more_anim".to_string()},
+                ZOP::Jump{jump_to_label: "system_check_more_timer_loop".to_string()},
+                ZOP::Quit,
 
-            ZOP::SetTextStyle{bold: false, reverse: false, monospace: true, italic: false},
-            ZOP::SetColor{foreground: 2, background: 9},
-            ZOP::Print{text: " ZWREEC Easter egg <3".to_string()},
-            ZOP::Newline,
+                ZOP::Routine{name: "system_check_more_anim".to_string(), count_variables: 5},
+                ZOP::EraseWindow{value: -1},
 
-            ZOP::StoreVariable{variable: Variable::new(1), value: Operand::new_const(20)},
-            ZOP::Label{name: "system_check_more_loop".to_string()},
-            ZOP::Random{range: Operand::new_const(8), variable: Variable::new(4)},
-            ZOP::Random{range: Operand::new_const(100), variable: Variable::new(5)},
-            ZOP::Add{operand1: Operand::new_var(5), operand2: Operand::new_const(10), save_variable: Variable::new(5)},
-            ZOP::Inc{variable: 4},
-            ZOP::SetColorVar{foreground: 4, background: 4},
-            ZOP::Print{text: "aa".to_string()},
-            ZOP::Inc{variable: 2},
+                ZOP::SetTextStyle{bold: false, reverse: false, monospace: true, italic: false},
+                ZOP::SetColor{foreground: 2, background: 9},
+                ZOP::Print{text: " ZWREEC Easter egg <3".to_string()},
+                ZOP::Newline,
 
-            ZOP::JL{operand1: Operand::new_var(2), operand2: Operand::new_var(1), jump_to_label: "system_check_more_loop".to_string()},
-            ZOP::Newline,
-            ZOP::Inc{variable: 3},
-            ZOP::StoreVariable{variable: Variable::new(2), value: Operand::new_const(0)},
-            ZOP::JL{operand1: Operand::new_var(3), operand2: Operand::new_var(1), jump_to_label: "system_check_more_loop".to_string()},
-            ZOP::Ret{value: Operand::new_const(0)}
-        ]);
+                ZOP::StoreVariable{variable: Variable::new(1), value: Operand::new_const(20)},
+                ZOP::Label{name: "system_check_more_loop".to_string()},
+                ZOP::Random{range: Operand::new_const(8), variable: Variable::new(4)},
+                ZOP::Random{range: Operand::new_const(100), variable: Variable::new(5)},
+                ZOP::Add{operand1: Operand::new_var(5), operand2: Operand::new_const(10), save_variable: Variable::new(5)},
+                ZOP::Inc{variable: 4},
+                ZOP::SetColorVar{foreground: 4, background: 4},
+                ZOP::Print{text: "aa".to_string()},
+                ZOP::Inc{variable: 2},
+
+                ZOP::JL{operand1: Operand::new_var(2), operand2: Operand::new_var(1), jump_to_label: "system_check_more_loop".to_string()},
+                ZOP::Newline,
+                ZOP::Inc{variable: 3},
+                ZOP::StoreVariable{variable: Variable::new(2), value: Operand::new_const(0)},
+                ZOP::JL{operand1: Operand::new_var(3), operand2: Operand::new_var(1), jump_to_label: "system_check_more_loop".to_string()},
+                ZOP::Ret{value: Operand::new_const(0)}
+            ]);
+        } else {
+            self.emit(vec![
+                ZOP::Routine{name: "system_check_more".to_string(), count_variables: 1},
+                ZOP::Ret{value: Operand::new_const(0)}
+            ]);
+        }
     }
 
     /// print UTF-16 string from addr

--- a/src/zwreec/config/mod.rs
+++ b/src/zwreec/config/mod.rs
@@ -165,6 +165,7 @@ pub struct Config {
     pub force: bool,
     /// Add easter egg to compiler
     pub easter_egg: bool,
+    pub force_unicode: bool,
     /// Instruct compiler to run these test-cases
     pub test_cases: Vec<TestCase>,
 }
@@ -182,6 +183,7 @@ impl Config {
         Config{
             force: false,
             easter_egg: true,
+            force_unicode: false,
             test_cases: Vec::new(),
         }
     }
@@ -225,6 +227,10 @@ impl Config {
                      cfg.easter_egg = true;
                      debug!("enabled easter-egg");
                 },
+                "force-unicode" => {
+                     cfg.force_unicode = true;
+                     debug!("enabled force-unicode");
+                },
                 _ => {
                     error!("Cannot enable feature {} - feature not known.", s);
                 }
@@ -236,6 +242,10 @@ impl Config {
                 "easter-egg" => {
                     cfg.easter_egg = false;
                     debug!("disabled easter-egg");
+                },
+                "force-unicode" => {
+                     cfg.force_unicode = false;
+                     debug!("enabled force-unicode");
                 },
                 _ => {
                     error!("Cannot disable feature {} - feature not known.", s);
@@ -319,7 +329,8 @@ pub fn zwreec_options(mut opts: getopts::Options) -> getopts::Options {
     opts.optmulti("F", "feature", "", "FEAT");
     opts.optmulti("N", "no-feature", "enable or disable a feature (can occur multiple times).
                         List of supported features (default):
-                            easter-egg (enabled)", "FEAT");
+                            easter-egg (enabled)
+                            force-unicode (disabled)", "FEAT");
     opts.optflag("e", "generate-sample-zcode", "writes out a sample zcode file, input file is not used and can be omitted");
 
     opts

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -37,7 +37,7 @@ impl<'a> Codegen<'a> {
         Codegen {
             cfg: cfg,
             ast: ast,
-            zfile: Zfile::new()
+            zfile: Zfile::new_with_cfg(cfg)
         }
     }
 


### PR DESCRIPTION
Manche Zeichen werden falsch dargestellt, wenn sie in per unicode-in-zstring durch die Tabelle angezeigt werden. Daher gibt es nun die Möglichkeit, direkt UTF16 dafür zu verwenden mit -F force-unicode. Daher wird jetzt auch der Name in zizek.z8 richtig angezeigt, ist schon so hochgeladen in Sammlung/works/
