### PR TITLE
supports passage tags, if we want to support them in the future.

### DIFF
--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -393,15 +393,16 @@ mod tests {
 
     #[test]
     fn text_test() {
-        let ast = test_ast("::Passage\nTestText\nTestNextLine\n::NextPassage");
+        let ast = test_ast("::Start\nTestText\nTestNextLine\n::NextPassage\nOtherText");
 
         let expected = vec!(
-            (vec![0]  , TokPassage {name: "Passage".to_string(), location: (0, 0)}),
+            (vec![0]  , TokPassage {location: (0, 0), name: "Start".to_string()}),
             (vec![0,0], TokText {location: (0, 0), text: "TestText".to_string()}),
             (vec![0,1], TokNewLine {location: (0, 0)} ),
-            (vec![0,2], TokText {location: (0, 0), text: "".to_string()}),
+            (vec![0,2], TokText {location: (0, 0), text: "nTestNextLine".to_string()}),
             (vec![0,1], TokNewLine {location: (0, 0)}),
-            (vec![1]  , TokPassage {name: "".to_string(), location: (0, 0)}),
+            (vec![1]  , TokPassage {location: (0, 0), name: "NextPassage".to_string()}),
+            (vec![1,0], TokText {location: (0, 0), text: "OtherText".to_string()}),
 
         );
 

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -50,6 +50,8 @@ pub enum NonTerminalType {
     Passage,
     Passagef,
     PassageContent,
+    Tags,
+    Tagsf,
     Formating,
     BoldFormatting,
     ItalicFormatting,
@@ -189,11 +191,53 @@ impl<'a> Parser<'a> {
 
                     None
                 },
+                (Sf, _ ) => {                    
+                    // Sf -> ε
+
+                    None
+                },
+
+                // Passage
                 (Passage, tok @ TokPassage { .. } ) => {
-                    stack.push(NonTerminal(PassageContent));
+                    stack.push(NonTerminal(Passagef));
                     stack.push(Terminal(tok.clone()));
 
                     Some(AddPassage(tok))
+                },
+
+                // Passagef
+                (Passagef, tok @ TokTagStart { .. } ) => {
+                    stack.push(NonTerminal(PassageContent));
+                    stack.push(Terminal(TokTagEnd{location: (0, 0)}));
+                    stack.push(NonTerminal(Tags));
+                    stack.push(Terminal(tok));
+
+                    None
+                },
+                (Passagef, _ ) => {
+                    stack.push(NonTerminal(PassageContent));
+
+                    None
+                },
+
+                // Tags
+                (Tags, tok @ TokTag { .. } ) => {                    
+                    stack.push(NonTerminal(Tagsf));
+                    stack.push(Terminal(tok));
+
+                    None
+                },
+
+                // tagsf
+                (Tagsf, TokTag { .. } ) => {                    
+                    stack.push(NonTerminal(Tags));
+
+                    None
+                },
+                (Tagsf, _ ) => {                    
+                    // Tagsf -> ε
+
+                    None
                 },
 
                 // PassageContent


### PR DESCRIPTION
Vor allem weil tags in vielen Realbeispielen vorkommen hatten wir entweder die Möglichkeit die Passage-Tags im Lexer zu überspringen oder im Parser zu akzeptieren.
Ich hab letzteres implementiert, falls wir doch noch Passage-Tags unterstützen sollten.
