### PR TITLE
Behebt bekannten Lexerfehler für weitere häufige Zeichen

### DIFF
--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -19,7 +19,7 @@ rustlex! TweeLexer {
     let TEXT_INITIAL = INITIAL_START_CHAR INITIAL_CHAR*;
 
     // If for example // is at a beginning of a line, then // is matched and not just /
-    let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ" | [^"*!>#"'\n']; // add chars longer than one byte
+    let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ"|"“"|"„"|"»"|"«"|"‘"|"’" | [^"*!>#"'\n']; // add chars longer than one byte
     let TEXT_CHAR = [^"/'_=~^{@<[" '\n'];
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
 

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -19,7 +19,7 @@ rustlex! TweeLexer {
     let TEXT_INITIAL = INITIAL_START_CHAR INITIAL_CHAR*;
 
     // If for example // is at a beginning of a line, then // is matched and not just /
-    let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ"|"“"|"„"|"»"|"«"|"‘"|"’" | [^"*!>#"'\n']; // add chars longer than one byte
+    let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ"|"“"|"„"|"»"|"«"|"‘"|"’"|"…" | [^"*!>#"'\n']; // add chars longer than one byte
     let TEXT_CHAR = [^"/'_=~^{@<[" '\n'];
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
 


### PR DESCRIPTION
Wenn eine Zeile mit einem Buchstaben aus mehreren Bytes wie diesen beginnt, wurden sie bisher zerrissen, was zum Absturz führt und daher werden sie nun extra erkannt.
