### PR TITLE
This hopefully fixes rustlex unicode handling.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ test = false
 doc = false
 
 [build-dependencies]
-rustlex_codegen = { version = "*", git = "https://github.com/Drakulix/rustlex", features = ["with-syntex"] }
+rustlex_codegen = { version = "*", git = "https://github.com/farthen/rustlex", rev = "279baaccc00c51daceaf2bbc137d0bc4f0a38e45", features = ["with-syntex"] }
 syntex          = "*"
 
 [dependencies]
@@ -34,4 +34,4 @@ libc = "*"
 log = "*"
 term = "0.2"
 getopts = "0.2.10"
-rustlex_codegen = { version = "*", git = "https://github.com/Drakulix/rustlex", rev = "72118ae0e9ada69a115984ad8e53260c8b50363c", features = ["with-syntex"] }
+rustlex_codegen = { version = "*", git = "https://github.com/farthen/rustlex", rev = "279baaccc00c51daceaf2bbc137d0bc4f0a38e45", features = ["with-syntex"] }

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -19,7 +19,7 @@ rustlex! TweeLexer {
     let TEXT_INITIAL = INITIAL_START_CHAR INITIAL_CHAR*;
 
     // If for example // is at a beginning of a line, then // is matched and not just /
-    let TEXT_START_CHAR = "ä"|"Ä"|"ü"|"Ü"|"ö"|"Ö"|"ß"|"ẞ"|"“"|"„"|"»"|"«"|"‘"|"’"|"…" | [^"*!>#"'\n']; // add chars longer than one byte
+    let TEXT_START_CHAR = [^"*!>#"'\n']; // add chars longer than one byte
     let TEXT_CHAR = [^"/'_=~^{@<[" '\n'];
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
 

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -19,7 +19,7 @@ rustlex! TweeLexer {
     let TEXT_INITIAL = INITIAL_START_CHAR INITIAL_CHAR*;
 
     // If for example // is at a beginning of a line, then // is matched and not just /
-    let TEXT_START_CHAR = [^"*!>#"'\n']; // add chars longer than one byte
+    let TEXT_START_CHAR = [^"*!>#"'\n'];
     let TEXT_CHAR = [^"/'_=~^{@<[" '\n'];
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
 


### PR DESCRIPTION
See https://github.com/Farthen/rustlex/commit/279baaccc00c51daceaf2bbc137d0bc4f0a38e45 for details on the changes.

Das Problem war folgendes: Ein Wildcard match mit einem Charakter, der länger als ein Byte war hat sofort returned und nicht noch die zusätzlichen Bytes eingelesen. Jetzt wird das gemacht und zusätzlich auch immer nur auf das _erste_ Byte in Unicode Charaktern gematcht, die anderen werden einfach ignoriert und eingelesen.
