### PR TITLE
Check Z-Code version in the integration tests.

### DIFF
--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -28,6 +28,12 @@ fn test_compile(input_filename: String) {
     let cfg = zwreec::config::Config::default_config();
 
     zwreec::compile(cfg, &mut input, &mut output);
+
+    let outvec = output.into_inner();
+
+    // check that the z-code version is 8
+    // this ensures that at least some z-code was emitted
+    assert_eq!(0x08, outvec[0]);
 }
 
 #[test]


### PR DESCRIPTION
This ensures that at least some Z-Code was emitted after running the test.
