### PR TITLE
Bugfix/unicode table

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -230,7 +230,7 @@ impl Zfile {
 
         let alpha_addr: u16 = 0x40;
         let extension_addr: u16 = alpha_addr + 78;
-        self.unicode_table_addr = extension_addr as u16 + 4;
+        self.unicode_table_addr = extension_addr as u16 + 8;
 
         // 1 byte for the unicode count, 97 possible chars with 2 bytes
         self.global_addr = self.unicode_table_addr + 195;
@@ -289,9 +289,9 @@ impl Zfile {
 
         // header extension table
         self.data.write_u16(3, extension_addr as usize);     // Number of further words in table
-        self.data.write_u16(0, extension_addr as usize + 1); // x-coordinate of mouse after a click
-        self.data.write_u16(0, extension_addr as usize + 2); // y-coordinate of mouse after a click
-        self.data.write_u16(0, extension_addr as usize + 3); // if != 0: unicode translation table address (optional)
+        self.data.write_u16(0, extension_addr as usize + 2); // x-coordinate of mouse after a click
+        self.data.write_u16(0, extension_addr as usize + 4); // y-coordinate of mouse after a click
+        self.data.write_u16(self.unicode_table_addr, extension_addr as usize + 6); // if != 0: unicode translation table address (optional)
 
         // global variables
         // ...

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -562,7 +562,7 @@ impl Zfile {
                     current_utf16.clear();
                     // unicode exist in table
                     current_text.push(character);
-                } else if self.force_unicode == false && self.unicode_table.len() < 97 {
+                } else if self.force_unicode == false && self.unicode_table.len() < 96 {
                     self.gen_write_out_unicode(current_utf16.to_string());  // write out utf16 string
                     current_utf16.clear();
                     // there is space in the unicode table

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -197,7 +197,7 @@ impl Zfile {
 
     /// creates a new zfile
     pub fn new() -> Zfile {
-        Zfile::new_with_options(true, false)
+        Zfile::new_with_options(false, false)
     }
 
     pub fn new_with_options(force_unicode: bool, easter_egg: bool) -> Zfile {

--- a/src/zwreec/config/mod.rs
+++ b/src/zwreec/config/mod.rs
@@ -183,7 +183,7 @@ impl Config {
         Config{
             force: false,
             easter_egg: true,
-            force_unicode: true,
+            force_unicode: false,
             test_cases: Vec::new(),
         }
     }
@@ -330,7 +330,7 @@ pub fn zwreec_options(mut opts: getopts::Options) -> getopts::Options {
     opts.optmulti("N", "no-feature", "enable or disable a feature (can occur multiple times).
                         List of supported features (default):
                             easter-egg (enabled)
-                            force-unicode (enabled)", "FEAT");
+                            force-unicode (disabled)", "FEAT");
     opts.optflag("e", "generate-sample-zcode", "writes out a sample zcode file, input file is not used and can be omitted");
 
     opts


### PR DESCRIPTION
-addresse der unicodetable wird nun richtig gesetzt
-werte in header-extensions-table wird richtig gesetzt
-verhindert das zu viele zeichen in die tabelle geschrieben werden (zoom stürzt bei <97 ab, deshalb <96)

(der bug hat mich viel viel zeit gekostet -.-)
