### PR TITLE
Even better errors

### DIFF
--- a/src/bin/logger/filelog.rs
+++ b/src/bin/logger/filelog.rs
@@ -66,7 +66,7 @@ impl Log for FileLogger {
             let _ = match record.level() {
                 LogLevel::Trace => {
                     writeln!(file_lock,
-                        "[{}] {}: ({:02}:{:02}:{:02}) [{}:{}] - {}",
+                        "{:02}:{:02}:{:02} [{}] {}: [{}:{}] {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,
@@ -79,7 +79,7 @@ impl Log for FileLogger {
                 },
                 _ => {
                     writeln!(file_lock,
-                        "[{}] {}: ({:02}:{:02}:{:02}) - {}",
+                        "{:02}:{:02}:{:02} [{}] {}: {}",
                             record.level(),
                             record.target(),
                             cur_time.tm_hour,

--- a/src/bin/logger/simplelog.rs
+++ b/src/bin/logger/simplelog.rs
@@ -65,24 +65,24 @@ impl Log for SimpleLogger {
             let _ = match record.level() {
                 LogLevel::Trace =>
                     writeln!(stderr_lock,
-                        "[{}] {}: ({:02}:{:02}:{:02}) [{}:{}] - {}",
-                            record.level(),
-                            record.target(),
+                        "{:02}:{:02}:{:02} [{}] {}: [{}:{}] {}",
                             cur_time.tm_hour,
                             cur_time.tm_min,
                             cur_time.tm_sec,
+                            record.level(),
+                            record.target(),
                             record.location().file(),
                             record.location().line(),
                             record.args()
                     ),
                 _ =>
                     writeln!(stderr_lock,
-                        "[{}] {}: ({:02}:{:02}:{:02}) - {}",
-                            record.level(),
-                            record.target(),
+                        "{:02}:{:02}:{:02} [{}] {}: {}",
                             cur_time.tm_hour,
                             cur_time.tm_min,
                             cur_time.tm_sec,
+                            record.level(),
+                            record.target(),
                             record.args()
                     ),
             };

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -33,7 +33,7 @@ struct Codegen<'a> {
 }
 
 impl<'a> Codegen<'a> {
-    pub fn new(cfg: &Config, ast: ast::AST) -> Codegen {
+    pub fn new(cfg: &'a Config, ast: ast::AST) -> Codegen<'a> {
         Codegen {
             cfg: cfg,
             ast: ast,

--- a/src/zwreec/frontend/expressionparser.rs
+++ b/src/zwreec/frontend/expressionparser.rs
@@ -3,21 +3,34 @@
 //! The idea is explained here: http://programmers.stackexchange.com/questions/254074/
 
 //use frontend::ast::*;
+use config::Config;
 use frontend::ast::{ASTNode, NodeDefault};
 use frontend::lexer::Token;
 use frontend::lexer::Token::*;
 
-
-pub struct ExpressionParser {
-    expr_stack: Vec<ASTNode>,
-    oper_stack: Vec<Token>,
+#[derive(Debug)]
+pub enum ExpressionParserError {
+    OperStackIsEmpty,
+    NoParseableSubExpression,
+    MoreThanOneRootExpression { count: usize, stack: Vec<ASTNode> },
+    NotEnoughElementsOnStack,
+    MissingNodeForBinaryNode,
+    DisallowedOperator { op: Token },
+    NotImplementedOperator { op: String },
 }
 
-impl ExpressionParser {
-    pub fn parse(node: &mut NodeDefault) {
+pub struct ExpressionParser<'a> {
+    expr_stack: Vec<ASTNode>,
+    oper_stack: Vec<Token>,
+    cfg: &'a Config,
+}
+
+impl<'a> ExpressionParser<'a> {
+    pub fn parse(node: &mut NodeDefault, cfg: &'a Config) {
         let mut expr_parser = ExpressionParser {
             expr_stack: Vec::new(),
             oper_stack: Vec::new(),
+            cfg: cfg,
         };
         expr_parser.parse_expressions(node);
     }
@@ -51,9 +64,12 @@ impl ExpressionParser {
                         let i_rev = length - i - 1;
                         let token: Token = match self.oper_stack.get(i_rev) {
                             Some(tok) => tok.clone(),
-                            None      => panic!{"No token in the operators stack."}
+                            None      => {
+                                error_panic!(self.cfg => ExpressionParserError::OperStackIsEmpty);
+                                return
+                            }
                         };
-                        if is_ranking_not_higher(token.clone(), tok.clone()) {
+                        if self.is_ranking_not_higher(token.clone(), tok.clone()) {
                             self.new_operator_node();
                         }
                         
@@ -71,12 +87,12 @@ impl ExpressionParser {
                     // and then parse it again
                     let childs_copy = top.as_default().childs.to_vec();
                     let mut ast_node = NodeDefault { category: tok.clone(), childs: childs_copy };
-                    ExpressionParser::parse(&mut ast_node);
+                    ExpressionParser::parse(&mut ast_node, self.cfg);
 
                     if let Some(temp) = ast_node.childs.get(0) {
                         self.expr_stack.push(temp.clone());
                     } else {
-                        panic!{"no parsable sub-expression"}
+                        error_panic!(self.cfg => ExpressionParserError::NoParseableSubExpression);
                     }
                 },
                 _ => ()
@@ -97,7 +113,11 @@ impl ExpressionParser {
         }
 
         // finished. so add the root of the expressions as child.
-        assert!{self.expr_stack.len() == 1, "Only one expression can be the root. But there are {:?}.", self.expr_stack.len()};
+        if self.expr_stack.len() != 1 {
+            error_panic!(self.cfg => ExpressionParserError::MoreThanOneRootExpression { count: self.expr_stack.len(),
+                stack: self.expr_stack.clone() });
+        }
+
         if let Some(root) = self.expr_stack.pop() {
             node.childs.push(root);
         }
@@ -120,7 +140,10 @@ impl ExpressionParser {
             if self.expr_stack.len() > 0 {
                 let e2: ASTNode = match self.expr_stack.pop() {
                     Some(tok) => tok,
-                    None      => panic!{"Not enough elements on the stack to create a node"}
+                    None      => {
+                        error_panic!(self.cfg => ExpressionParserError::NotEnoughElementsOnStack);
+                        return
+                    }
                 };
 
                 let mut new_node: ASTNode;
@@ -130,7 +153,10 @@ impl ExpressionParser {
                 } else {
                     let e1: ASTNode = match self.expr_stack.pop() {
                         Some(tok) => tok,
-                        None      => panic!{"Missing Node to create binary node"}
+                        None      => {
+                            error_panic!(self.cfg => ExpressionParserError::MissingNodeForBinaryNode);
+                            return
+                        }
                     };
                     new_node = ASTNode::Default(NodeDefault { category: top_op.clone(), childs: vec![e1, e2] });
                 }
@@ -142,58 +168,67 @@ impl ExpressionParser {
             }
         }
     }
-}
 
-/// checks the operatores of two tokens returns true if operator of token1
-/// is more important then operator of token2
-/// the ranking is set in "operator_precedence"
-fn is_ranking_not_higher(token1: Token, token2: Token) -> bool {
-    let op1: String = match token1 {
-        TokUnaryMinus{ .. } => "_".to_string(),
-        TokNumOp     { op_name, .. } |
-        TokCompOp    { op_name, .. } |
-        TokLogOp     { op_name, .. } => {
-            op_name.clone()
-        },
-        _ => panic!{"not allowed operator"}
-    };
-    let op2: String = match token2 {
-        TokUnaryMinus{ .. } => "_".to_string(),
-        TokNumOp     { op_name, .. } |
-        TokCompOp    { op_name, .. } |
-        TokLogOp     { op_name, .. } => {
-            op_name.clone()
-        },
-        _ => panic!{"not allowed operator"}
-    };
+    /// checks the operatores of two tokens returns true if operator of token1
+    /// is more important then operator of token2
+    /// the ranking is set in "operator_precedence"
+    fn is_ranking_not_higher(&self, token1: Token, token2: Token) -> bool {
+        let op1: String = match token1 {
+            TokUnaryMinus{ .. } => "_".to_string(),
+            TokNumOp     { op_name, .. } |
+            TokCompOp    { op_name, .. } |
+            TokLogOp     { op_name, .. } => {
+                op_name.clone()
+            },
+            _ => {
+                error_panic!(self.cfg => ExpressionParserError::DisallowedOperator { op: token1.clone() });
+                return false
+            }
+        };
+        let op2: String = match token2 {
+            TokUnaryMinus{ .. } => "_".to_string(),
+            TokNumOp     { op_name, .. } |
+            TokCompOp    { op_name, .. } |
+            TokLogOp     { op_name, .. } => {
+                op_name.clone()
+            },
+            _ => {
+                error_panic!(self.cfg => ExpressionParserError::DisallowedOperator { op: token2.clone() });
+                return false
+            }
+        };
 
 
-    // special handling for the unary operators (two unary operators in a row)
-    //let op1_copy: &str = op1.as_slice();
-    if (op1 == "_" || op1 == "not" || op1 == "!") &&
-        operator_rank(op1.clone()) == operator_rank(op2.clone()) {
+        // special handling for the unary operators (two unary operators in a row)
+        //let op1_copy: &str = op1.as_slice();
+        if (op1 == "_" || op1 == "not" || op1 == "!") &&
+            self.operator_rank(op1.clone()) == self.operator_rank(op2.clone()) {
 
-        return false
+            return false
+        }
+
+        //
+        if self.operator_rank(op1) >= self.operator_rank(op2) {
+            return true
+        }
+
+        false
     }
 
-    //
-    if operator_rank(op1) >= operator_rank(op2) {
-        return true
-    }
-
-    false
-}
-
-/// ranking of the operators
-fn operator_rank(op: String) -> u8 {
-    match op.as_ref() {
-        "or" | "||"         => 1,
-        "and" | "&&"        => 2,
-        "is" | "==" | "eq" | "neq" | ">" | "gt" | ">=" | "gte" | "<" | "lt" | "<=" | "lte"
-                            => 3,
-        "+" | "-"           => 4,
-        "*" | "/" | "%"     => 5,
-        "_" | "not" | "!"   => 6, // _ is unary minus
-        _                   => panic!{"This operator is not implemented"}
+    /// ranking of the operators
+    fn operator_rank(&self, op: String) -> u8 {
+        match op.as_ref() {
+            "or" | "||"         => 1,
+            "and" | "&&"        => 2,
+            "is" | "==" | "eq" | "neq" | ">" | "gt" | ">=" | "gte" | "<" | "lt" | "<=" | "lte"
+                                => 3,
+            "+" | "-"           => 4,
+            "*" | "/" | "%"     => 5,
+            "_" | "not" | "!"   => 6, // _ is unary minus
+            _                   => {
+                error_panic!(self.cfg => ExpressionParserError::NotImplementedOperator { op: op });
+                0
+            }
+        }
     }
 }

--- a/src/zwreec/frontend/mod.rs
+++ b/src/zwreec/frontend/mod.rs
@@ -21,7 +21,8 @@
 //!
 //! // Parse Tokens
 //! let p = zwreec::frontend::parser::Parser::new(&cfg);
-//! let ast = zwreec::frontend::ast::AST::build(
+//! let ast_builder = zwreec::frontend::ast::ASTBuilder::new(&cfg);
+//! let ast = ast_builder.build(
 //!     p.parse(tokens)
 //! );
 //! ```

--- a/src/zwreec/lib.rs
+++ b/src/zwreec/lib.rs
@@ -140,11 +140,14 @@ pub fn compile<R: Read, W: Write>(cfg: Config, input: &mut R, output: &mut W) {
     // tokenize
     let tokens = frontend::lexer::lex(&cfg, input);
 
-    //create parser
+    // create parser
     let parser = frontend::parser::Parser::new(&cfg);
 
+    // create ast builder
+    let ast_builder = frontend::ast::ASTBuilder::new(&cfg);
+
     //build up ast from tokens
-    let ast = frontend::ast::AST::build(parser.parse(tokens.inspect(|ref token| {
+    let ast = ast_builder.build(parser.parse(tokens.inspect(|ref token| {
         debug!("{:?}", token);
     })));
     ast.print(false);

--- a/src/zwreec/utils/error.rs
+++ b/src/zwreec/utils/error.rs
@@ -2,6 +2,7 @@ use std::fmt::{Display, Formatter, Result, Write};
 
 use frontend::lexer::Token;
 use frontend::parser::ParserError;
+use frontend::expressionparser::ExpressionParserError;
 
 macro_rules! error_panic(
     ($cfg:expr => $($arg:tt)+) => (
@@ -25,8 +26,8 @@ impl Display for Token {
 }
 
 impl Display for ParserError {
-    fn fmt(&self, f: &mut Formatter) -> Result{
-        try!(f.write_str("[!!!] Critical Parser Error [!!!]"));
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        try!(f.write_str("[!!!] Critical Parser Error [!!!]\n"));
         match self {
             &ParserError::TokenDoNotMatch{ref token, ref stack} =>
                 match token {
@@ -36,6 +37,36 @@ impl Display for ParserError {
             &ParserError::StackIsEmpty{ref token} => try!(f.write_fmt(format_args!("Tokens left but Stack is empty. Token:{:?}", token))),
             &ParserError::NoProjection{ref token, ref stack} => try!(f.write_fmt(format_args!("No Projection found for Token:{:?} and NonTerminal:{:?}", token, stack))),
             &ParserError::NonTerminalEnd{ref stack} => try!(f.write_fmt(format_args!("NonTerminal:{:?} is no allowed End", stack))),
+        };
+        Ok(())
+    }
+}
+
+impl Display for ExpressionParserError {
+    fn fmt(&self, f: &mut Formatter) -> Result {
+        try!(f.write_str("[!!!] Critical Expression Parser Error [!!!]\n"));
+        match self {
+            &ExpressionParserError::OperStackIsEmpty => {
+                try!(f.write_str("No token in the operators stack."))
+            },
+            &ExpressionParserError::NoParseableSubExpression => {
+                try!(f.write_str("No parsable sub-expression"))
+            },
+            &ExpressionParserError::MoreThanOneRootExpression { count, ref stack } => {
+                try!(f.write_fmt(format_args!("Only one expression can be the root. But there are {}. Stack: {:?}", count, stack)))
+            },
+            &ExpressionParserError::NotEnoughElementsOnStack => {
+                try!(f.write_str("Not enough elements on the stack to create a node"))
+            },
+            &ExpressionParserError::MissingNodeForBinaryNode => {
+                try!(f.write_str("Missing Node to create binary node"))
+            },
+            &ExpressionParserError::DisallowedOperator { ref op } => {
+                try!(f.write_fmt(format_args!("Checking the operator ranking for operator '{:?}' failed: The operator is not allowed in this context.", op)))
+            },
+            &ExpressionParserError::NotImplementedOperator { ref op } => {
+                try!(f.write_fmt(format_args!("This operator is not implemented: '{}'", op)))
+            }
         };
         Ok(())
     }


### PR DESCRIPTION
Nice error messages for the expression parser. This required a refactor of the
AST. The AST is now split in the ASTBuilder which is used by the parser and the
static AST tree. Debug was also implemented for AST and ASTNode to make it
easier to debug the AST.

Also change logger to have the time at the front of the message:
This makes everything look less messy. Also refactor termlog.rs to not panic
if the log output could not be opened.
