### PR TITLE
Konvertierung int -> bool an Twee angepasst

### DIFF
--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -171,7 +171,7 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                     let if_label = format!("if_{}", if_id);
                     let after_if_label = format!("after_if_{}", if_id);
                     let after_else_label = format!("after_else_{}", if_id);
-                    code.push(ZOP::JG{operand1: result, operand2: Operand::new_const(0), jump_to_label: if_label.to_string()});
+                    code.push(ZOP::JNE{operand1: result, operand2: Operand::new_const(0), jump_to_label: if_label.to_string()});
                     code.push(ZOP::Jump{jump_to_label: after_if_label.to_string()});
                     code.push(ZOP::Label{name: if_label.to_string()});
 
@@ -206,7 +206,7 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                     let if_label = format!("if_{}", if_id);
                     let after_if_label = format!("after_if_{}", manager.ids_if.pop_id());
                     let after_else_label = format!("after_else_{}", manager.ids_if.peek());
-                    code.push(ZOP::JG{operand1: result, operand2: Operand::new_const(0), jump_to_label: if_label.to_string()});
+                    code.push(ZOP::JNE{operand1: result, operand2: Operand::new_const(0), jump_to_label: if_label.to_string()});
                     code.push(ZOP::Jump{jump_to_label: after_if_label.to_string()});
                     code.push(ZOP::Label{name: if_label.to_string()});
 

--- a/src/zwreec/frontend/evaluate_expression.rs
+++ b/src/zwreec/frontend/evaluate_expression.rs
@@ -286,7 +286,7 @@ fn eval_not<'a>(eval: &Operand, code: &mut Vec<ZOP>,
         temp_ids: &mut Vec<u8>, mut manager: &mut CodeGenManager<'a>) -> Operand {
     if eval.is_const() {
         let val = eval.const_value();
-        let result: u8 = if val > 0 { 0 } else { 1 };
+        let result: u8 = if val != 0 { 0 } else { 1 };
         return Operand::Const(Constant { value: result });
     }
     let save_var: Variable = match temp_ids.pop() {
@@ -295,7 +295,7 @@ fn eval_not<'a>(eval: &Operand, code: &mut Vec<ZOP>,
     };
     let label = format!("expr_{}", manager.ids_expr.start_next());
     code.push(ZOP::StoreVariable{ variable: save_var.clone(), value: Operand::new_const(0)});
-    code.push(ZOP::JG{operand1: eval.clone(), operand2: Operand::new_const(0), jump_to_label: label.to_string()});
+    code.push(ZOP::JNE{operand1: eval.clone(), operand2: Operand::new_const(0), jump_to_label: label.to_string()});
     code.push(ZOP::StoreVariable{ variable: save_var.clone(), value: Operand::new_const(1)});
     code.push(ZOP::Label {name: label.to_string()});
     free_var_if_temp(eval, temp_ids);


### PR DESCRIPTION
Vorher hatten wir val > 0 <=> true, jetzt haben wir, wie in Twee, val != 0 <=> true.
