### PR TITLE
Feature/more links

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -741,7 +741,6 @@ impl Zfile {
 
             // detect keys for <9 links
             ZOP::Label{name: "system_check_links_loop".to_string()},
-            ZOP::Print{text: "DETECT < 9".to_string()},
             ZOP::ReadChar{local_var_id: 0x01},
             // check for the start of the konami code
             ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(129), jump_to_label: "system_check_links_jmp".to_string()},
@@ -751,14 +750,6 @@ impl Zfile {
 
             ZOP::Label{name: "system_check_links_after".to_string()},
             ZOP::Sub{operand1: Operand::new_var(1), operand2: Operand::new_const(48), save_variable: Variable::new(1)},
-
-            // temp
-            /*ZOP::PrintNumVar{variable: Variable::new(1)},
-            ZOP::Newline,
-            ZOP::PrintNumVar{variable: Variable::new(16)},
-            ZOP::Newline,*/
-
-            // check if the number is possible
             // check if the the detected key is > numbers of links
             // => "wrong key => jump before key-detection
             ZOP::JG{operand1: Operand::new_var(1), operand2: Operand::new_var(16), jump_to_label: "system_check_links_loop".to_string()},
@@ -771,13 +762,11 @@ impl Zfile {
 
             // detect keys for >9 links
             ZOP::Label{name: "system_check_links_more_than_9".to_string()},
-            ZOP::Print{text: ">9 links".to_string()},
             // detect frst position
             ZOP::ReadChar{local_var_id: 1},
             ZOP::Sub{operand1: Operand::new_var(1), operand2: Operand::new_const(48), save_variable: Variable::new(1)},
             ZOP::PrintNumVar{variable: Variable::new(1)},
 
-            // check if the number is possible
             // check if the the detected key is > 9
             ZOP::JG{operand1: Operand::new_var(1), operand2: Operand::new_const(9), jump_to_label: "system_check_links_error".to_string()},
             // check if key < 1, 0 is not valid
@@ -800,20 +789,9 @@ impl Zfile {
             // first position, so multiply with 10
             ZOP::Mul{operand1: Operand::new_var(1), operand2: Operand::new_const(10), save_variable: Variable::new(3)},
             ZOP::Add{operand1: Operand::new_var(3), operand2: Operand::new_var(2), save_variable: Variable::new(3)},
-            ZOP::Newline,
-            ZOP::PrintNumVar{variable: Variable::new(3)},
-            ZOP::Print{text: "_".to_string()},
-            ZOP::PrintNumVar{variable: Variable::new(16)},
-            ZOP::Newline,
             // check if the the calculated number > number of link
             ZOP::JG{operand1: Operand::new_var(3), operand2: Operand::new_var(16), jump_to_label: "system_check_links_error".to_string()},
 
-
-            // detect return
-            //ZOP::ReadChar{local_var_id: 3},
-
-            // check if the last key is an enter => jump to load address
-            //ZOP::JE{operand1: Operand::new_var(3), operand2: Operand::new_const(13), jump_to_label: "system_check_links_error".to_string()},
             ZOP::Jump{jump_to_label: "system_check_links_load_link_address".to_string()},
             // error
             ZOP::Label{name: "system_check_links_error".to_string()},
@@ -823,7 +801,6 @@ impl Zfile {
 
             // loads the address of the link from the array
             ZOP::Label{name: "system_check_links_load_link_address".to_string()},
-            ZOP::Print{text: "LOAD ADDRESS".to_string()},
             // decrement 0x03 becouse the array starts at 0 and not at 1
             ZOP::Dec{variable: 3},
             ZOP::LoadW{array_address: Operand::new_large_const(save_at_addr as i16), index: Variable::new(3), variable: Variable::new(2)},

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -719,8 +719,11 @@ impl Zfile {
     }
 
 
-    /// checks all stored links and make them choiceable
-    /// with the keyboard
+    /// checks all stored links and make them choiceable with the keyboard
+    /// the routine checks if there are if there are < 10 links or more:
+    /// if < 10: key 1-9 are supported, jumps immediately
+    /// if >=10: 99 links are supported, on the first position is no 0 allowed
+    ///          to jump to a < 10 link you have to press enter
     pub fn routine_check_links(&mut self) {
         let save_at_addr: u16 = 1 + self.object_addr;
         self.emit(vec![

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -737,7 +737,7 @@ impl Zfile {
             ZOP::SetTextStyle{bold: false, reverse: false, monospace: true, italic: false},
             ZOP::Print{text: "---------------------------------------".to_string()},
             ZOP::Newline,
-            ZOP::Print{text: "Please press a number to select a link:".to_string()},
+            ZOP::Print{text: "Please press a number to select a link (end with Q):".to_string()},
             ZOP::Newline,
 
             // check if there are more than 9 links
@@ -746,6 +746,8 @@ impl Zfile {
             // detect keys for <9 links
             ZOP::Label{name: "system_check_links_loop".to_string()},
             ZOP::ReadChar{local_var_id: 0x01},
+            // Quit programme on Q
+            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(81), jump_to_label: "system_check_links_end_quit".to_string()},
             // check for the start of the konami code
             ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(129), jump_to_label: "system_check_links_jmp".to_string()},
             ZOP::Jump{jump_to_label: "system_check_links_after".to_string()},
@@ -768,6 +770,8 @@ impl Zfile {
             ZOP::Label{name: "system_check_links_more_than_9".to_string()},
             // detect frst position
             ZOP::ReadChar{local_var_id: 1},
+            // Quit programme on Q
+            ZOP::JE{operand1: Operand::new_var(0x01), operand2: Operand::new_const(81), jump_to_label: "system_check_links_end_quit".to_string()},
             ZOP::Sub{operand1: Operand::new_var(1), operand2: Operand::new_const(48), save_variable: Variable::new(1)},
             ZOP::PrintNumVar{variable: Variable::new(1)},
 

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -734,9 +734,10 @@ impl Zfile {
 
             // jumps to the end, if there a no links
             ZOP::JE{operand1: Operand::new_var(16), operand2: Operand::new_const(0x00), jump_to_label: "system_check_links_end_quit".to_string()},
-            ZOP::Print{text: "--------------------".to_string()},
+            ZOP::SetTextStyle{bold: false, reverse: false, monospace: true, italic: false},
+            ZOP::Print{text: "---------------------------------------".to_string()},
             ZOP::Newline,
-            ZOP::Print{text: "press a key... ".to_string()},
+            ZOP::Print{text: "Please press a number to select a link:".to_string()},
             ZOP::Newline,
 
             // check if there are more than 9 links
@@ -804,6 +805,7 @@ impl Zfile {
 
             // loads the address of the link from the array
             ZOP::Label{name: "system_check_links_load_link_address".to_string()},
+            ZOP::SetTextStyle{bold: false, reverse: false, monospace: false, italic: false},
             // decrement 0x03 becouse the array starts at 0 and not at 1
             ZOP::Dec{variable: 3},
             ZOP::LoadW{array_address: Operand::new_large_const(save_at_addr as i16), index: Variable::new(3), variable: Variable::new(2)},


### PR DESCRIPTION
would fix #181 

nun sind 99 links anwählbar. das sollte definitiv reichen.
wenn <10 links vorhanden sind, kann wie gewohnt eine zahl von 1-9 eingegeben werden und es wird die neue passage angewählt.
falls >= 10 links vorhanden sind, dann gibt es 2 möglichkeiten: wenn ein links <10 angewählt werden soll, dann muss nach der 1. zahl mit enter bestätigt werden. falls höher gesprungen werden soll, dann wird kein enter benötigt sondern nach der 2. ziffer zu der entsprechenden passage gesprungen.

ich es mit folgender datei getestet:

```
::Start
Test Links:
[[1]]
[[2]]
[[3]]
[[4]]
[[5]]
[[6]]
[[7]]
[[8]]
[[9]]
[[10]]
[[11]]
[[12]]

::1
1 [[Start]]

::2
2 [[Start]]

::3
3 [[Start]]

::4
4 [[Start]]

::5
5 [[Start]]

::6
6 [[Start]]

::7
7 [[Start]]

::8
8 [[Start]]

::9
9 [[Start]]

::10
10 [[Start]]

::11
11 [[Start]]

::12
12 [[Start]]
```
