### PR TITLE
Feature/html filter

### DIFF
--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -683,4 +683,50 @@ mod tests {
 
         assert_tok_eq(expected, tokens);
     }
+
+    #[test]
+    fn html_filter_test() {
+        let tokens = test_lex("Text\n\n::Start\n<!DOCTYPE html>\n<html lang=\"de\">\n\n<head>\n  <meta charset=\"UTF-8\"/>\n  <title>Example</title>\n  <img src=\"smiley.gif\" alt=\"Smiley face\" height=\"42\" width=\"42\">\n  <style type=\"text/css\">\n    <a href=\"http://www.w3schools.com\">Visit W3Schools.com!</a>\n  </style>\n\n</head>\n<body>\n\n</body>\n</html>\n\n::Passage1 [stylesheet]\ntext shouldn't be displayed\n\n::Passage2\ntext <html><b>should</b></html> be displayed\n\n::Passage3 [script]\ntext shouldn't be displayed\n");
+        let expected = vec![
+            TokPassage {name: "Start".to_string(), location: (3, 3)},
+            TokNewLine { location: (4, 16) },
+            TokNewLine { location: (5, 17) },
+            TokNewLine { location: (6, 1) },
+            TokNewLine { location: (7, 7) },
+            TokText { location: (8, 1), text: "  ".to_string() },
+            TokNewLine { location: (8, 26) },
+            TokText { location: (9, 1), text: "  Example".to_string() },
+            TokNewLine { location: (9, 25) },
+            TokText { location: (10, 1), text: "  ".to_string() },
+            TokNewLine { location: (10, 66) },
+            TokText { location: (11, 1), text: "  ".to_string() },
+            TokNewLine { location: (11, 26) },
+            TokText { location: (12, 1), text: "    Visit W3Schools.com!".to_string() },
+            TokNewLine { location: (12, 64) },
+            TokText { location: (13, 1), text: "  ".to_string() },
+            TokNewLine { location: (13, 11) },
+            TokNewLine { location: (14, 1) },
+            TokNewLine { location: (15, 8) },
+            TokNewLine { location: (16, 7) },
+            TokNewLine { location: (17, 1) },
+            TokNewLine { location: (18, 8) },
+            TokNewLine { location: (19, 8) },
+            TokNewLine { location: (20, 1) },
+            TokPassage { location: (21, 3), name: "Passage1".to_string() },
+            TokTagStart { location: (21, 12) },
+            TokTag { location: (21, 13), tag_name: "stylesheet".to_string() },
+            TokTagEnd { location: (21, 23) },
+            TokPassage { location: (24, 3), name: "Passage2".to_string() },
+            TokText { location: (25, 1), text: "text should be displayed".to_string() },
+            TokNewLine { location: (25, 45) },
+            TokNewLine { location: (26, 1) },
+            TokPassage { location: (27, 3), name: "Passage3".to_string() },
+            TokTagStart { location: (27, 12) },
+            TokTag { location: (27, 13), tag_name: "script".to_string() },
+            TokTagEnd { location: (27, 19) },
+
+        ];
+
+        assert_tok_eq(expected, tokens);
+    }
 }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -672,4 +672,15 @@ mod tests {
 
         assert_tok_eq(expected, tokens);
     }
+
+    #[test]
+    fn url_test() {
+        let tokens = test_lex("::Start\nhttp://foo.com/blah_blahhttp://foo.com/blah_blah/ http://foo.com/blah_blah_(wikipedia) http://foo.com/blah_blah_(wikipedia)_(again) http://www.example.com/wpstyle/?p=364 https://www.example.com/foo/?bar=baz&inga=42&quux http://✪df.ws/123 http://userid:password@example.com:8080 http://userid:password@example.com:8080/ http://userid@example.com http://userid@example.com/ http://userid@example.com:8080 http://userid@example.com:8080/ http://userid:password@example.com http://userid:password@example.com/ http://142.42.1.1/ http://142.42.1.1:8080/ http://➡.ws/䨹 http://⌘.ws http://⌘.ws/ http://foo.com/blah_(wikipedia)#cite-1 http://foo.com/blah_(wikipedia)_blah#cite-1 http://foo.com/unicode_(✪)_in_parens http://foo.com/(something)?after=parens http://☺.damowmow.com/ http://code.google.com/events/#&product=browser http://j.mp ftp://foo.bar/baz http://foo.bar/?q=Test%20URL-encoded%20stuff http://例子.测试 http://उदाहरण.परीक्षा http://-.~_!$&'()*+,;=:%40:80%2f::::::@example.com http://1337.net http://a.b-c.de http://223.255.255.254");
+        let expected = vec![
+            TokPassage {name: "Start".to_string(), location: (1, 3)},
+            TokText {text: "http://foo.com/blah_blahhttp://foo.com/blah_blah/ http://foo.com/blah_blah_(wikipedia) http://foo.com/blah_blah_(wikipedia)_(again) http://www.example.com/wpstyle/?p=364 https://www.example.com/foo/?bar=baz&inga=42&quux http://\u{272a}df.ws/123 http://userid:password@example.com:8080 http://userid:password@example.com:8080/ http://userid@example.com http://userid@example.com/ http://userid@example.com:8080 http://userid@example.com:8080/ http://userid:password@example.com http://userid:password@example.com/ http://142.42.1.1/ http://142.42.1.1:8080/ http://➡.ws/䨹 http://⌘.ws http://⌘.ws/ http://foo.com/blah_(wikipedia)#cite-1 http://foo.com/blah_(wikipedia)_blah#cite-1 http://foo.com/unicode_(\u{272a})_in_parens http://foo.com/(something)?after=parens http://\u{263a}.damowmow.com/ http://code.google.com/events/#&product=browser http://j.mp ftp://foo.bar/baz http://foo.bar/?q=Test%20URL-encoded%20stuff http://\u{4f8b}\u{5b50}.\u{6d4b}\u{8bd5} http://\u{909}\u{926}\u{93e}\u{939}\u{930}\u{923}.\u{92a}\u{930}\u{940}\u{915}\u{94d}\u{937}\u{93e} http://-.~_!$&\'()*+,;=:%40:80%2f::::::@example.com http://1337.net http://a.b-c.de http://223.255.255.254".to_string(), location: (2, 1)},
+        ];
+
+        assert_tok_eq(expected, tokens);
+    }
 }


### PR DESCRIPTION
1. HTML Regex eingebaut, sodass Tags und auch nur Tags gefiltert werden (aktuell sind's aber nicht alle, eventuell hat ja einer ne bessere Idee bevor ich das vervollständige?)
2. URL Regex eingebaut basierend auf https://mathiasbynens.be/demo/url-regex, damit "//" in einer URL nicht als kursive Textformatierung erkannt wird
3. Tests für beide Regex geschrieben
4. Regex ein wenig umbenannt und verschoben als Vorbereitung auf die Kommentare morgen
5. TokFormatBul entfernt

Würde teilweise #192 und #219 fixen.
