### PR TITLE
Boolean als Typ und Dynamische Typen fast überall

### DIFF
--- a/src/zwreec/backend/zcode/mod.rs
+++ b/src/zwreec/backend/zcode/mod.rs
@@ -6,7 +6,7 @@ pub mod zfile;
 pub mod ztext;
 pub mod op;
 
-use self::zfile::{Zfile, Operand, Variable, ZOP};
+use self::zfile::{Zfile, Operand, Variable, ZOP, Type};
 
 use std::error::Error;
 use std::io::Write;
@@ -20,11 +20,16 @@ pub fn temp_create_zcode_example<W: Write>(output: &mut W) {
 
     zfile.start();
     zfile.emit(vec![
-        ZOP::Routine{name: "Start".to_string(), count_variables: 3},
-        ZOP::Add{operand1: Operand::new_var(1), operand2: Operand::new_var(1), save_variable: Variable::new(1)},
-        ZOP::Call2S{jump_to_label: "itoa".to_string(), arg: Operand::new_large_const(17), result: Variable::new(1)},
+        ZOP::Routine{name: "Start".to_string(), count_variables: 14},
+        ZOP::StoreVariable{variable: Variable::new(1), value: Operand::new_large_const(1337)},
+        ZOP::Call2S{jump_to_label: "itoa".to_string(), arg: Operand::new_large_const(1337), result: Variable::new(2)},
+        ZOP::SetVarType{variable: Variable::new(1), vartype: Type::Integer},
+        ZOP::SetVarType{variable: Variable::new(2), vartype: Type::String},
+        ZOP::AddTypes{operand1: Operand::new_var(1), operand2: Operand::new_var(2), tmp1: Variable::new(3), tmp2: Variable::new(4), save_variable: Variable::new(1)},
+        ZOP::AddTypes{operand1: Operand::new_var(1), operand2: Operand::new_var(2), tmp1: Variable::new(3), tmp2: Variable::new(4), save_variable: Variable::new(1)},
         ZOP::PrintUnicodeStr{address: Operand::new_var(1)},
-        ZOP::PrintOps{text: "it works".to_string()},
+        ZOP::Newline,
+        ZOP::PrintVar{variable: Variable::new(1)},
         ZOP::Quit,
         ]);
     zfile.end();

--- a/src/zwreec/backend/zcode/op.rs
+++ b/src/zwreec/backend/zcode/op.rs
@@ -61,6 +61,39 @@ pub fn op_storeb(array_address: &Operand, index: &Variable, variable: &Variable)
     bytes
 }
 
+/// stores a value to an array
+/// stores the value of operand to the address in: array_address + index
+pub fn op_storeboperand(array_address: &Operand, index: &Operand, operand: &Operand) -> Vec<u8> {
+    // assert!(array_address > 0, "not allowed array-address, becouse in _some_ interpreters (for example zoom) it crahs. -.-");
+    let args: Vec<ArgType> = vec![arg_type(&array_address), arg_type(&index), arg_type(&operand), ArgType::Nothing];
+    let mut bytes = op_var(0x02, args);
+
+    // array address
+    write_argument(array_address, &mut bytes);
+
+    // array index
+    write_argument(index, &mut bytes);
+
+    // value
+    write_argument(operand, &mut bytes);
+    bytes
+}
+
+/// loads a byte from an array in a variable
+/// loadb is an 2op, BUT with 3 ops -.-
+pub fn op_loadb(array_address: &Operand, index: &Operand, variable: &Variable) -> Vec<u8> {
+    let mut bytes = op_2(0x10, vec![arg_type(&array_address), arg_type(&index)]);
+
+    // array address
+    write_argument(array_address, &mut bytes);
+    // array index
+    write_argument(index, &mut bytes);
+
+    // variable
+    bytes.push(variable.id);
+    bytes
+}
+
 
 /// loads a word from an array in a variable
 /// loadw is an 2op, BUT with 3 ops -.-
@@ -410,6 +443,7 @@ pub fn arg_type(operand: &Operand) -> ArgType {
     match operand {
         &Operand::Var(_) => ArgType::Variable,
         &Operand::Const(_) => ArgType::SmallConst,
+        &Operand::BoolConst(_) => ArgType::SmallConst,
         &Operand::LargeConst(_) => ArgType::LargeConst,
         &Operand::StringRef(_) => ArgType::LargeConst,
     }
@@ -419,6 +453,7 @@ pub fn write_argument(operand: &Operand, v: &mut Vec<u8>){
     match operand {
         &Operand::Var(ref var)=> v.push(var.id),
         &Operand::Const(ref constant) => v.push(constant.value),
+        &Operand::BoolConst(ref constant) => v.push(constant.value),
         &Operand::LargeConst(ref constant) => write_i16(constant.value, v),
         &Operand::StringRef(ref constant) => write_i16(constant.value, v),
     };

--- a/src/zwreec/backend/zcode/op.rs
+++ b/src/zwreec/backend/zcode/op.rs
@@ -159,8 +159,8 @@ pub fn op_print_num_var(variable: &Variable) -> Vec<u8> {
 }
 
 
-/// pulls an value off the stack to an variable
-/// SmallConst because pull takes an reference to an variable
+/// pulls an value off the stack to a variable
+/// SmallConst because pull takes an reference to a variable
 pub fn op_pull(variable: u8) -> Vec<u8> {
     let args: Vec<ArgType> = vec![ArgType::SmallConst, ArgType::Nothing, ArgType::Nothing, ArgType::Nothing];
     let mut bytes = op_var(0x09, args);
@@ -184,6 +184,14 @@ pub fn op_push_u16(value: u16) -> Vec<u8> {
     let args: Vec<ArgType> = vec![ArgType::LargeConst, ArgType::Nothing, ArgType::Nothing, ArgType::Nothing];
     let mut bytes = op_var(0x08, args);
     write_u16(value, &mut bytes);
+    bytes
+}
+
+/// pushs a variable on the stack
+pub fn op_push_var(variable: &Variable) -> Vec<u8> {
+    let args: Vec<ArgType> = vec![ArgType::Variable, ArgType::Nothing, ArgType::Nothing, ArgType::Nothing];
+    let mut bytes = op_var(0x08, args);
+    bytes.push(variable.id);
     bytes
 }
 
@@ -232,9 +240,18 @@ pub fn op_ret(value: &Operand) -> Vec<u8> {
 }
 
 
-// saves an u8 to the variable
+// saves an operand to the variable
 pub fn op_store_var(variable: &Variable, value: &Operand) -> Vec<u8> {
     let args: Vec<ArgType> = vec![ArgType::Reference, arg_type(&value)];
+    let mut bytes = op_2(0x0d, args);
+    bytes.push(variable.id);
+    write_argument(value, &mut bytes);
+    bytes
+}
+
+// saves an operand to the variable id which is given as operand
+pub fn op_store_var_id(variable: &Variable, value: &Operand) -> Vec<u8> {
+    let args: Vec<ArgType> = vec![ArgType::Variable, arg_type(&value)];
     let mut bytes = op_2(0x0d, args);
     bytes.push(variable.id);
     write_argument(value, &mut bytes);

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -207,11 +207,11 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                                     code.push(ZOP::AddTypes{operand1: Operand::new_var(symbol_id.id), operand2: result, tmp1: Variable::new(tmp1), tmp2: Variable::new(tmp2), save_variable: symbol_id.clone()});
                                     },
                         "-=" => { code.push(ZOP::Sub{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                   },
+                                  code.push(ZOP::SetVarType{variable: Variable::new(symbol_id.id), vartype: Type::Integer}); },
                         "*=" => { code.push(ZOP::Mul{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                   },
+                                  code.push(ZOP::SetVarType{variable: Variable::new(symbol_id.id), vartype: Type::Integer}); },
                         "/=" =>  {code.push(ZOP::Div{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                   },
+                                  code.push(ZOP::SetVarType{variable: Variable::new(symbol_id.id), vartype: Type::Integer}); },
                         _ => {}
                     };
                     

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -160,7 +160,7 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                         vec![
                         ZOP::Call2NWithAddress{jump_to_label: "system_add_link".to_string(), address: passage_name.to_string()},
                         ZOP::SetColor{foreground: 8, background: 2},
-                        ZOP::Print{text: format!("{}[", display_name)},
+                        ZOP::PrintOps{text: format!("{}[", display_name)},
                         ZOP::PrintNumVar{variable: Variable::new(16)},
                         ZOP::Print{text: "]".to_string()},
                         ZOP::SetColor{foreground: 9, background: 2},

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -198,14 +198,20 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                         "=" | "to" => { code.push(ZOP::StoreVariable{variable: symbol_id.clone(), value: result.clone()});
                                         code.push(ZOP::CopyVarType{variable: symbol_id.clone(), from: result});
                                       },
-                        "+=" => { code.push(ZOP::Add{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                  code.push(ZOP::SetVarType{variable: symbol_id.clone(), vartype: symbol_id.vartype}); },
+                        "+=" => {   // using temp local variables which are not the result's variable
+                                    let tmp1: u8 = match result {
+                                        Operand::Var(ref var) => if var.id < 3 { 15 } else { 2 },
+                                        _ => 15
+                                    };
+                                    let tmp2: u8 = tmp1-1;
+                                    code.push(ZOP::AddTypes{operand1: Operand::new_var(symbol_id.id), operand2: result, tmp1: Variable::new(tmp1), tmp2: Variable::new(tmp2), save_variable: symbol_id.clone()});
+                                    },
                         "-=" => { code.push(ZOP::Sub{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                  code.push(ZOP::SetVarType{variable: symbol_id.clone(), vartype: symbol_id.vartype}); },
+                                   },
                         "*=" => { code.push(ZOP::Mul{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                  code.push(ZOP::SetVarType{variable: symbol_id.clone(), vartype: symbol_id.vartype}); },
+                                   },
                         "/=" =>  {code.push(ZOP::Div{operand1: Operand::new_var(symbol_id.id), operand2: result, save_variable: symbol_id.clone()});
-                                  code.push(ZOP::SetVarType{variable: symbol_id.clone(), vartype: symbol_id.vartype}); },
+                                   },
                         _ => {}
                     };
                     

--- a/src/zwreec/frontend/evaluate_expression.rs
+++ b/src/zwreec/frontend/evaluate_expression.rs
@@ -336,7 +336,7 @@ fn eval_comp_op<'a>(eval0: &Operand, eval1: &Operand, op_name: &str, location: (
         };
     }
     code.push(ZOP::Label {name: label.to_string()});
-    code.push(ZOP::SetVarType{variable: save_var.clone(), vartype: save_var.vartype.clone()});
+    code.push(ZOP::SetVarType{variable: save_var.clone(), vartype: Type::Bool});
     free_var_if_temp(eval0, temp_ids);
     free_var_if_temp(eval1, temp_ids);
     Operand::Var(save_var)
@@ -443,7 +443,7 @@ fn eval_unary_minus<'a>(eval: &Operand, code: &mut Vec<ZOP>, temp_ids: &mut Vec<
     };
 
     code.push(ZOP::Sub {operand1: Operand::new_const(0), operand2: eval.clone(), save_variable: save_var.clone()});
-    code.push(ZOP::SetVarType{variable: save_var.clone(), vartype: save_var.vartype.clone()});
+    code.push(ZOP::SetVarType{variable: save_var.clone(), vartype: Type::Integer});
 
     Operand::new_var(save_var.id)
 }


### PR DESCRIPTION
Boolean als neuer Typ (also macht jetzt print false, was wir erwarten würden)

Typveränderungen werden registriert und in einem Speicherabschnitt gehalten, aber noch wird nicht diese Information, sondern immer noch die Symboltabelle für Variablen genutzt. Das wird in einem neuen PR kommen. Daher ist jetzt die Veränderung nur bei Konstanten zu sehen.
