### PR TITLE
zwei Feature-Flags für ältere Umgebungen und ein Bugfix

### DIFF
--- a/src/zwreec/backend/zcode/op.rs
+++ b/src/zwreec/backend/zcode/op.rs
@@ -118,7 +118,7 @@ pub fn op_read_char(local_var_id: u8) -> Vec<u8> {
     let mut bytes = op_var(0x16, args);
 
     // write argument value
-    bytes.push(0x00);
+    bytes.push(0x01);
 
     // write varible id
     bytes.push(local_var_id);

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -1675,7 +1675,7 @@ impl Zfile {
         self.op_var(0x16, args);
 
         // write argument value
-        self.data.append_byte(0x00);
+        self.data.append_byte(0x01);
 
         // write timer
         self.data.append_byte(timer);

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -222,22 +222,22 @@ impl Zfile {
 
     /// creates a new zfile
     pub fn new() -> Zfile {
-        Zfile::new_with_options(false, false, false)
+        Zfile::new_with_options(false, false, false, false)
     }
 
-    pub fn new_with_options(force_unicode: bool, easter_egg: bool, no_colours: bool) -> Zfile {
+    pub fn new_with_options(force_unicode: bool, easter_egg: bool, no_colours: bool, half_memory: bool) -> Zfile {
         Zfile {
             data: Bytes{bytes: Vec::new()},
             unicode_table: Vec::new(),
             jumps: Vec::new(),
             labels: Vec::new(),
             strings: Vec::new(),
-            program_addr: 0xfff8,
+            program_addr: if half_memory { 0x7918 } else { 0xfff8 },
             unicode_table_addr: 0,
             global_addr: 0,
             object_addr: 0,
             static_addr: 0,
-            last_static_written: 0x8000,
+            last_static_written: if half_memory { 0x4000 } else { 0x8000 },
             heap_start: 0x600,
             type_store: 0x400,
             force_unicode: force_unicode,
@@ -247,7 +247,7 @@ impl Zfile {
     }
 
     pub fn new_with_cfg(cfg: &Config) -> Zfile {
-        Zfile::new_with_options(cfg.force_unicode, cfg.easter_egg, cfg.no_colours)
+        Zfile::new_with_options(cfg.force_unicode, cfg.easter_egg, cfg.no_colours, cfg.half_memory)
     }
 
     /// creates the header of a zfile

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -237,7 +237,7 @@ impl Zfile {
             global_addr: 0,
             object_addr: 0,
             static_addr: 0,
-            last_static_written: if half_memory { 0x4000 } else { 0x8000 },
+            last_static_written: if half_memory { 0x2000 } else { 0x8000 },
             heap_start: 0x600,
             type_store: 0x400,
             force_unicode: force_unicode,

--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -1917,7 +1917,7 @@ fn test_op_set_text_style() {
 
 #[test]
 fn test_op_read_char() {
-    assert_eq!(op::op_read_char(0x01),vec![0xF6,0x7F,0x00,0x01]);
+    assert_eq!(op::op_read_char(0x01),vec![0xF6,0x7F,0x01,0x01]);
 }
 
 #[test]

--- a/src/zwreec/config/mod.rs
+++ b/src/zwreec/config/mod.rs
@@ -168,6 +168,7 @@ pub struct Config {
     pub easter_egg: bool,
     pub force_unicode: bool,
     pub no_colours: bool,
+    pub half_memory: bool,
     /// Instruct compiler to run these test-cases
     pub test_cases: Vec<TestCase>,
 }
@@ -187,6 +188,7 @@ impl Config {
             easter_egg: true,
             force_unicode: false,
             no_colours: false,
+            half_memory: false,
             test_cases: Vec::new(),
         }
     }
@@ -238,6 +240,10 @@ impl Config {
                      cfg.no_colours = true;
                      debug!("enabled no-colours");
                 },
+                "half-memory" => {
+                     cfg.half_memory = true;
+                     debug!("enabled half-memory");
+                },
                 _ => {
                     error!("Cannot enable feature {} - feature not known.", s);
                 }
@@ -257,6 +263,10 @@ impl Config {
                 "no-colours" => {
                      cfg.no_colours = false;
                      debug!("disabled no-colours");
+                },
+                "half-memory" => {
+                     cfg.half_memory = false;
+                     debug!("disabled half-memory");
                 },
                 _ => {
                     error!("Cannot disable feature {} - feature not known.", s);
@@ -371,7 +381,10 @@ pub fn zwreec_usage(verbose: bool, mut opts: getopts::Options, brief: &str) -> S
         translation table
     no-colours (disabled)
         Suppress generation of set_colour opcodes and disable the colour bit
-        in the second byte of the header"
+        in the second byte of the header
+    half-memory (disabled)
+        Cut down space for static variable strings and heap in order to have
+        binaries smaller than 64kB"
     } else {
         "Additional help:
     --help -v           Print the full set of options zwreec accepts"

--- a/src/zwreec/config/mod.rs
+++ b/src/zwreec/config/mod.rs
@@ -167,6 +167,7 @@ pub struct Config {
     /// Add easter egg to compiler
     pub easter_egg: bool,
     pub force_unicode: bool,
+    pub no_colours: bool,
     /// Instruct compiler to run these test-cases
     pub test_cases: Vec<TestCase>,
 }
@@ -185,6 +186,7 @@ impl Config {
             force: false,
             easter_egg: true,
             force_unicode: false,
+            no_colours: false,
             test_cases: Vec::new(),
         }
     }
@@ -232,6 +234,10 @@ impl Config {
                      cfg.force_unicode = true;
                      debug!("enabled force-unicode");
                 },
+                "no-colours" => {
+                     cfg.no_colours = true;
+                     debug!("enabled no-colours");
+                },
                 _ => {
                     error!("Cannot enable feature {} - feature not known.", s);
                 }
@@ -246,7 +252,11 @@ impl Config {
                 },
                 "force-unicode" => {
                      cfg.force_unicode = false;
-                     debug!("enabled force-unicode");
+                     debug!("disabled force-unicode");
+                },
+                "no-colours" => {
+                     cfg.no_colours = false;
+                     debug!("disabled no-colours");
                 },
                 _ => {
                     error!("Cannot disable feature {} - feature not known.", s);
@@ -358,7 +368,10 @@ pub fn zwreec_usage(verbose: bool, mut opts: getopts::Options, brief: &str) -> S
     force-unicode (disabled)
         Force the generation of unicode print opcodes every time a unicode
         character is encountered. This disables the generation of the unicode
-        translation table"
+        translation table
+    no-colours (disabled)
+        Suppress generation of set_colour opcodes and disable the colour bit
+        in the second byte of the header"
     } else {
         "Additional help:
     --help -v           Print the full set of options zwreec accepts"


### PR DESCRIPTION
Somit läuft unser Kompilat auch auf Atari und DOS.
-F no-colours -F half-memory
Bug war in read_char opcodes, wo 0 statt 1 als Gerät angegeben wurde.
