### PR TITLE
Feature/tok heading

### DIFF
--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -162,7 +162,7 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                         }
 
                         vec![
-                            ZOP::PrintOps{text: number_signs+&text.to_string()}
+                            ZOP::PrintOps{text: number_signs+" "+&text.to_string()}
                         ]
                     }
                 },

--- a/src/zwreec/frontend/codegen.rs
+++ b/src/zwreec/frontend/codegen.rs
@@ -138,6 +138,34 @@ pub fn gen_zcode<'a>(node: &'a ASTNode, mut out: &mut Zfile, mut manager: &mut C
                 &TokNewLine { .. } => {
                     vec![ZOP::Newline]
                 },
+                &TokFormatHeading {ref rank, ref text, .. } => {
+                    if *rank <= 2 {
+                        let text_length = text.len();
+                        let mut line = "".to_string();
+                        for _ in 0..text_length {
+                            line.push_str( if *rank == 1 { "=" } else { "-" } );
+                        }
+                        
+                        vec![
+                            ZOP::Newline,
+                            ZOP::SetTextStyle{bold: true, reverse: state_copy.inverted, monospace: true, italic: state_copy.italic},
+                            ZOP::PrintOps{text: text.to_string()},
+                            ZOP::Newline,
+                            ZOP::PrintOps{text: line},
+                            ZOP::Newline,
+                            ZOP::SetTextStyle{bold: state_copy.bold, reverse: state_copy.inverted, monospace: state_copy.mono, italic: state_copy.italic}
+                        ]
+                    } else {
+                        let mut number_signs = "".to_string();
+                        for _ in 0..*rank {
+                            number_signs.push_str("#");
+                        }
+
+                        vec![
+                            ZOP::PrintOps{text: number_signs+&text.to_string()}
+                        ]
+                    }
+                },
                 &TokFormatBoldStart { .. } => {
                     state_copy.bold = true;
                     set_formatting = true;

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -146,7 +146,7 @@ pub enum Token {
     TokFormatNumbList         {location: (u64, u64)},
     TokFormatIndentBlock      {location: (u64, u64)},
     TokFormatHorizontalLine   {location: (u64, u64)},
-    TokFormatHeading          {location: (u64, u64), rank: usize, text: String},
+    TokFormatHeading          {location: (u64, u64), rank: u8, text: String},
     TokMacroStart             {location: (u64, u64)},
     TokMacroEnd               {location: (u64, u64)},
     TokMacroContentVar        {location: (u64, u64), var_name: String},

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -70,7 +70,7 @@ pub fn lex<'a, R: Read>(cfg: &'a Config, input: &'a mut R) -> FilteringScan<Peek
 
     let mut lexer = TweeLexer::new(BufReader::new(input));
     lexer.cfg = Some(cfg.clone());
-    
+
     lexer.peeking().scan_filter(
         ScanState {
             cfg: cfg,
@@ -146,7 +146,7 @@ pub enum Token {
     TokFormatNumbList         {location: (u64, u64)},
     TokFormatIndentBlock      {location: (u64, u64)},
     TokFormatHorizontalLine   {location: (u64, u64)},
-    TokFormatHeading          {location: (u64, u64), rank: usize},
+    TokFormatHeading          {location: (u64, u64), rank: usize, text: String},
     TokMacroStart             {location: (u64, u64)},
     TokMacroEnd               {location: (u64, u64)},
     TokMacroContentVar        {location: (u64, u64), var_name: String},

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -255,6 +255,12 @@ impl<'a> Parser<'a> {
 
                     None
                 },
+                (PassageContent, tok @ TokFormatHeading { .. } ) => {
+                    stack.push(NonTerminal(PassageContent));
+                    stack.push(Terminal(tok));
+
+                    None
+                },
                 (PassageContent, TokPassageLink { .. } ) => {
                     stack.push(NonTerminal(PassageContent));
                     stack.push(NonTerminal(Link));

--- a/src/zwreec/frontend/parser.rs
+++ b/src/zwreec/frontend/parser.rs
@@ -257,9 +257,9 @@ impl<'a> Parser<'a> {
                 },
                 (PassageContent, tok @ TokFormatHeading { .. } ) => {
                     stack.push(NonTerminal(PassageContent));
-                    stack.push(Terminal(tok));
+                    stack.push(Terminal(tok.clone()));
 
-                    None
+                    Some(AddChild(tok))
                 },
                 (PassageContent, TokPassageLink { .. } ) => {
                     stack.push(NonTerminal(PassageContent));

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -18,6 +18,7 @@ rustlex! TweeLexer {
     property format_sub_open:bool = false;
     property format_sup_open:bool = false;
     property function_parens:usize = 0;
+    property heading_rank:usize = 0;
 
     //=============================
     // regular expressions
@@ -59,6 +60,7 @@ rustlex! TweeLexer {
     let TEXT_CHAR_START = [^"!#"'\n'] | HTTP;
     let TEXT_CHAR = [^"/'_=~^{@<[" '\n'] | HTTP;
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
+    let TEXT_HEADING = [^'\n']+;
 
     let VARIABLE_CHAR = LETTER | DIGIT | UNDERSCORE;
     let VARIABLE = '$' (LETTER | UNDERSCORE) VARIABLE_CHAR*;
@@ -69,7 +71,7 @@ rustlex! TweeLexer {
     let FORMAT_STRIKE = "==";
     let FORMAT_SUB = "~~";
     let FORMAT_SUP = "^^";
-    let FORMAT_HEADING = ("!" | "!!" | "!!!" | "!!!!" | "!!!!!") WHITESPACE*;
+    let FORMAT_HEADING = ("!" | "!!" | "!!!" | "!!!!" | "!!!!!" );
     let FORMAT_NUMB_LIST = "#" WHITESPACE*;
     let FORMAT_INDENT_BLOCK = "<<<" NEWLINE;
     let FORMAT_HORIZONTAL_LINE = "----" NEWLINE;
@@ -248,9 +250,11 @@ rustlex! TweeLexer {
             lexer.NON_NEWLINE();
             Some(TokFormatNumbList {location: lexer.yylloc()} )
         }
-        FORMAT_HEADING  =>  |lexer:&mut TweeLexer<R>| {
-            lexer.NON_NEWLINE();
-            Some(TokFormatHeading {location: lexer.yylloc(), rank: lexer.yystr().trim().len()} )
+
+        FORMAT_HEADING  =>  |lexer:&mut TweeLexer<R>| -> Option<Token>{
+            lexer.heading_rank = lexer.yystr().trim().len();
+            lexer.HEADING();
+            None
         }
 
         TEXT_CHAR_START => |lexer:&mut TweeLexer<R>| {
@@ -301,6 +305,19 @@ rustlex! TweeLexer {
         TAG_END => |lexer:&mut TweeLexer<R>| {
             if !lexer.ignore_passage { lexer.PASSAGE(); } else { lexer.INITIAL(); }
             Some(TokTagEnd {location: lexer.yylloc()})
+        }
+    }
+
+    HEADING {
+
+        TEXT_HEADING => |lexer:&mut TweeLexer<R>| -> Option<Token> {
+            Some(TokFormatHeading {location: lexer.yylloc(), text: lexer.yystr().trim().to_string(), rank: lexer.heading_rank} )
+        }
+
+        NEWLINE =>  |lexer:&mut TweeLexer<R>| -> Option<Token> {
+            lexer.heading_rank = 0;
+            lexer.NEWLINE();
+            Some(TokNewLine {location: lexer.yylloc()} )
         }
     }
 

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -18,7 +18,7 @@ rustlex! TweeLexer {
     property format_sub_open:bool = false;
     property format_sup_open:bool = false;
     property function_parens:usize = 0;
-    property heading_rank:usize = 0;
+    property heading_rank:u8 = 0;
 
     //=============================
     // regular expressions
@@ -252,7 +252,7 @@ rustlex! TweeLexer {
         }
 
         FORMAT_HEADING  =>  |lexer:&mut TweeLexer<R>| -> Option<Token>{
-            lexer.heading_rank = lexer.yystr().trim().len();
+            lexer.heading_rank = lexer.yystr().trim().len() as u8;
             lexer.HEADING();
             None
         }


### PR DESCRIPTION
implementiert #232 "Umsetzung für TokHeading fehlt"

ich hab es erstmal so gemacht wir markdown:

```
::Start

!Title1
text1

!!Title2
text2

!!!Title3
text3

!!!!Title4
text4

!!!!Title5
text5

!!!!Title6
text6
```

wird du:
![head](https://cloud.githubusercontent.com/assets/1397415/8508613/84a0f74e-2277-11e5-95e3-8baede4ae30e.png)

vermutlich könnte das noch verschönert werden.
