### PR TITLE
Add newline escaping. A \ before a newline will ignore the newline.

### DIFF
--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -734,4 +734,28 @@ mod tests {
 
         assert_tok_eq(expected, tokens);
     }
+
+    #[test]
+    fn escape_line_break_test() {
+        let tokens = test_lex("::Start\nTest\\\n<<if true>>\\\nLi\\ne\n<<else>>\nBla\\\n<<endif>>\nTest");
+        let expected = vec![
+            TokPassage { name: "Start".to_string(), location: (1, 3) },
+            TokText { text: "Test".to_string(), location: (2, 1) },
+            TokMacroIf { location: (3, 3) },
+            TokBoolean { location: (3, 6), value: "true".to_string() },
+            TokMacroEnd { location: (3, 10) },
+            TokText { text: "Li\\ne".to_string(), location: (4, 1) },
+            TokNewLine { location: (4, 6) },
+            TokMacroElse { location: (5, 3) },
+            TokMacroEnd { location: (5, 7) },
+            TokNewLine { location: (5, 9) },
+            TokText { text: "Bla".to_string(), location: (6, 1) },
+            TokMacroEndIf { location: (7, 3) },
+            TokMacroEnd { location: (7, 8) },
+            TokNewLine { location: (7, 10) },
+            TokText { text: "Test".to_string(), location: (8, 1) },
+        ];
+
+        assert_tok_eq(expected, tokens);
+    }
 }

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -737,7 +737,7 @@ mod tests {
 
     #[test]
     fn escape_line_break_test() {
-        let tokens = test_lex("::Start\nTest\\\n<<if true>>\\\nLi\\ne\n<<else>>\nBla\\\n<<endif>>\nTest");
+        let tokens = test_lex("::Start\nTest\\\n<<if true>>\\\nLi\\ne\n<<else>>\nBla\\\n<<endif>>\n\\\nTest");
         let expected = vec![
             TokPassage { name: "Start".to_string(), location: (1, 3) },
             TokText { text: "Test".to_string(), location: (2, 1) },
@@ -753,7 +753,7 @@ mod tests {
             TokMacroEndIf { location: (7, 3) },
             TokMacroEnd { location: (7, 8) },
             TokNewLine { location: (7, 10) },
-            TokText { text: "Test".to_string(), location: (8, 1) },
+            TokText { text: "Test".to_string(), location: (9, 1) },
         ];
 
         assert_tok_eq(expected, tokens);

--- a/src/zwreec/frontend/rustlex.in.rs
+++ b/src/zwreec/frontend/rustlex.in.rs
@@ -56,8 +56,8 @@ rustlex! TweeLexer {
     let TAG = ['a'-'z''A'-'Z''0'-'9''.''_']+;
 
     // If for example // is at a beginning of a line, then // is matched and not just /
-    let TEXT_CHAR_START = [^"!#"'\n'] | HTTP;
-    let TEXT_CHAR = [^"/'_=~^{@<[" '\n'] | HTTP;
+    let TEXT_CHAR_START = [^"!#"'\n''\\'] | '\\'[^'\n'] | HTTP;
+    let TEXT_CHAR = [^"/'_=~^{@<[" '\n''\\'] | '\\'[^'\n'] | HTTP;
     let TEXT = TEXT_CHAR+ | ["/'_=~^{@<["];
 
     let VARIABLE_CHAR = LETTER | DIGIT | UNDERSCORE;
@@ -73,6 +73,7 @@ rustlex! TweeLexer {
     let FORMAT_NUMB_LIST = "#" WHITESPACE*;
     let FORMAT_INDENT_BLOCK = "<<<" NEWLINE;
     let FORMAT_HORIZONTAL_LINE = "----" NEWLINE;
+    let FORMAT_ESCAPE_NEWLINE = '\\' NEWLINE;
     let FORMAT_INLINE = "@@"; //TODO ignore content
 
     let FORMAT_MONO_START = "{{{";
@@ -126,7 +127,13 @@ rustlex! TweeLexer {
         COLON =>      |lexer:&mut TweeLexer<R>| Some(TokColon     {location: lexer.yylloc()} )
     }
 
+    I_ALLOW_NEWLINE_ESCAPE {
+        FORMAT_ESCAPE_NEWLINE => |_:&mut TweeLexer<R>| -> Option<Token> { None }
+    }
+
     I_PASSAGE_CONTENT {
+        :I_ALLOW_NEWLINE_ESCAPE
+
         MACRO_START => |lexer:&mut TweeLexer<R>| -> Option<Token>{
             lexer.MACRO();
             None


### PR DESCRIPTION
See http://twinery.org/wiki/syntax#escaped_line_breaks for details
