### PR TITLE
faster garbage collection

### DIFF
--- a/src/zwreec/backend/zcode/zfile.rs
+++ b/src/zwreec/backend/zcode/zfile.rs
@@ -252,7 +252,7 @@ impl Zfile {
             global_addr: 0,
             object_addr: 0,
             static_addr: 0,
-            last_static_written: if half_memory { 0x2000 } else { 0x8000 },
+            last_static_written: if half_memory { 0x4000 } else { 0x8000 },
             heap_start: 0x600,
             type_store: 0x400,
             force_unicode: force_unicode,
@@ -983,7 +983,10 @@ impl Zfile {
     /// malloc
     pub fn routine_malloc(&mut self) {
         let heap_start = self.heap_start;
-        let static_addr = self.static_addr;
+        let static_addr = self.static_addr - 2; // we'll write u16 before static_addr where we
+                                                // store the maximum of upper bounds of allocations
+                                                // so that the garbage collector does not need to clean
+                                                // if the memory was untouched
         self.emit(vec![
             ZOP::Routine{name: "malloc".to_string(), count_variables: 15},
             // var1 is the allocation size given in needed amount of u16
@@ -991,15 +994,21 @@ impl Zfile {
             // var2 contains entry at index var3 of var4
             // var3 is index on array at var4
             // var5 has the upper boundary for var4 which is at static_addr-length*2
+            // var6 contains the need_to_clean_up_to entry
             // init var4 with heap_start
             ZOP::StoreVariable{variable: Variable::new(4), value: Operand::new_large_const(heap_start as i16)},
             // calc var5
             ZOP::StoreVariable{variable: Variable::new(5), value: Operand::new_large_const(static_addr as i16)},
             ZOP::Sub{operand1: Operand::new_var(5), operand2: Operand::new_var(1), save_variable: Variable::new(5)},
             ZOP::Sub{operand1: Operand::new_var(5), operand2: Operand::new_var(1), save_variable: Variable::new(5)},
+            // load need_to_clean_up_to
+            ZOP::LoadW{array_address: Operand::new_large_const(static_addr as i16), index: Variable::new(6), variable: Variable::new(6)},
             ZOP::Label{name: "malloc_loop".to_string()},
             // check if we have to give up and quit
             ZOP::JGE{operand1: Operand::new_var(4), operand2: Operand::new_var(5), jump_to_label: "malloc_fail".to_string()},
+            // check if we are behind highest allocated block and do not need to check if it was freed
+            // @TODO: this should work with JE
+            ZOP::JGE{operand1: Operand::new_var(4), operand2: Operand::new_var(6), jump_to_label: "malloc_return".to_string()},
             // set var3 index to 0
             ZOP::StoreVariable{variable: Variable::new(3), value: Operand::new_large_const(0)},
             // read the entry of var4 at pos var3 to var2
@@ -1026,6 +1035,13 @@ impl Zfile {
             ZOP::Add{operand1: Operand::new_var(4), operand2: Operand::new_var(3), save_variable: Variable::new(4)},
             ZOP::Jump{jump_to_label: "malloc_loop".to_string()},
             ZOP::Label{name: "malloc_return".to_string()},
+            // save upper bound to the last u16 before (real) static_addr
+            // add up allocation address and allocation length*2 (as it is amount of u16)
+            ZOP::Add{operand1: Operand::new_var(4), operand2: Operand::new_var(1), save_variable: Variable::new(2)},
+            ZOP::Add{operand1: Operand::new_var(2), operand2: Operand::new_var(1), save_variable: Variable::new(2)},
+            ZOP::StoreVariable{variable: Variable::new(3), value: Operand::new_const(0)},
+            ZOP::StoreW{array_address: Operand::new_large_const(static_addr as i16), index: Variable::new(3), variable: Variable::new(2)},
+            // return allocation addr
             ZOP::Ret{value: Operand::new_var(4)},
             ZOP::Label{name: "malloc_fail".to_string()},
             ZOP::Print{text: "MALLOC FAIL".to_string()},
@@ -1153,18 +1169,21 @@ impl Zfile {
     /// malloc_init
     pub fn routine_malloc_init(&mut self) {
         let heap_start = self.heap_start;
-        let static_addr = self.static_addr;
+        let static_addr = self.static_addr - 2;  // store last alloc upper bound as u16 before static_addr
         self.emit(vec![
             ZOP::Routine{name: "malloc_init".to_string(), count_variables: 4},
             // var3 stays 0
             // heap_start is in var1 and will be increased during loop
             // var2 stays -1
             ZOP::StoreVariable{variable: Variable::new(1), value: Operand::new_large_const(heap_start as i16)},
-            ZOP::StoreVariable{variable: Variable::new(2), value: Operand::new_large_const(-1i16)},
-            ZOP::Label{name: "malloc_init_loop".to_string()},
-            ZOP::StoreW{array_address: Operand::new_var(1), index: Variable::new(3), variable: Variable::new(2)},
-            ZOP::Inc{variable: 1}, ZOP::Inc{variable: 1},
-            ZOP::JNE{operand1: Operand::new_var(1), operand2: Operand::new_large_const(static_addr as i16), jump_to_label: "malloc_init_loop".to_string()},
+            // write heap start as last used addr
+            ZOP::StoreW{array_address: Operand::new_large_const(static_addr as i16), index: Variable::new(3), variable: Variable::new(1)},
+            // init with -1 not needed as we use need_to_clean_up_to entry
+            //ZOP::StoreVariable{variable: Variable::new(2), value: Operand::new_large_const(-1i16)},
+            //ZOP::Label{name: "malloc_init_loop".to_string()},
+            //ZOP::StoreW{array_address: Operand::new_var(1), index: Variable::new(3), variable: Variable::new(2)},
+            //ZOP::Inc{variable: 1}, ZOP::Inc{variable: 1},
+            //ZOP::JNE{operand1: Operand::new_var(1), operand2: Operand::new_large_const(static_addr as i16), jump_to_label: "malloc_init_loop".to_string()},
             ZOP::Ret{value: Operand::new_const(0)}
         ]);
     }
@@ -1172,7 +1191,7 @@ impl Zfile {
     /// mem_free as a tracing garbage collection
     pub fn routine_mem_free(&mut self) {
         let heap_start = self.heap_start;
-        let static_addr = self.static_addr;
+        let static_addr = self.static_addr - 2;  // the last u16 contains the highest addr of allocated space
         let global_addr = self.global_addr;
         let type_store = self.type_store;
         let pos = Variable::new(1);
@@ -1182,8 +1201,10 @@ impl Zfile {
         let t = Variable::new(5);
         let varid = Variable::new(6);
         let varcontent = Variable::new(7);
+        let need_to_clean_up_to = Variable::new(8);  // @IMPROVEMENT: consider reducing it again if last element was freed
         self.emit(vec![
             ZOP::Routine{name: "mem_free".to_string(), count_variables: 15},
+            ZOP::LoadW{array_address: Operand::new_large_const(static_addr as i16), index: zero.clone(), variable: need_to_clean_up_to.clone()},
             // set m to -1
             ZOP::StoreVariable{variable: m.clone(), value: Operand::new_large_const(-1i16)},
             // set pos to current position
@@ -1195,6 +1216,8 @@ impl Zfile {
             ZOP::Inc{variable: pos.id},
             // exit at end of mem
             ZOP::JE{operand1: Operand::new_var(pos.id), operand2: Operand::new_large_const(static_addr as i16), jump_to_label: "mem_free_exit".to_string()},
+            // or also exit at end of up-to-now allocated memory
+            ZOP::JE{operand1: Operand::new_var(pos.id), operand2: Operand::new_var(need_to_clean_up_to.id), jump_to_label: "mem_free_exit".to_string()},
             // read entry to c
             ZOP::LoadW{array_address: Operand::new_var(pos.id), index: zero.clone(), variable: c.clone()},
             // continue search if entry is free


### PR DESCRIPTION
Ich weiß, es ist schwer nachzuvollziehen, was vor sich geht. Aber bisher wurde immer der ganze Heap durchlaufen, was auf langsamen Geräten (zB 8MHz) etwas ungünstig war. Das wurde behoben durch Merken des bisher angefassten Speicherbereiches und somit sollte alles so wie vorher sein. Wenn ihr also keinen Unterschied merkt, wär das gut.
