### PR TITLE
Feature/confirm

### DIFF
--- a/src/zwreec/frontend/evaluate_expression.rs
+++ b/src/zwreec/frontend/evaluate_expression.rs
@@ -202,7 +202,7 @@ fn evaluate_expression_internal<'a>(node: &'a ASTNode, code: &mut Vec<ZOP>,
                     code.push(ZOP::StoreVariable{variable: has_confirmed.clone(), value: Operand::BoolConst(Constant {value: 0})});
                     code.push(ZOP::Label{name: end_label.to_string()});
                     code.push(ZOP::SetTextStyle{bold: state_copy.bold, reverse: state_copy.inverted, monospace: state_copy.mono, italic: state_copy.italic});
-                    
+                    code.push(ZOP::SetVarType{variable: Variable::new(has_confirmed.id), vartype: Type::Bool});
                     Operand::new_var(has_confirmed.id)
                 },
                 _ => {


### PR DESCRIPTION
implementiert den "confirm"-teil von #238 
mit 1 wird bestätigt, mit 0 nicht.

mit folgender twee-datei getestet:

```
::Start

text bevor confirm

<<set $var=confirm("do you want to quit this programm?")>>
<<if $var==true>>
confirmed
<<else>>
not confirmed
<<endif>>

text after confirm
```
