### PR TITLE
Feature/multithreading

### DIFF
--- a/src/zwreec/frontend/ast.rs
+++ b/src/zwreec/frontend/ast.rs
@@ -39,8 +39,8 @@ impl ASTBuilder {
     }
 
     ///constructs Iterator over all Passages
-    pub fn build<I: Iterator<Item=ASTOperation>>(cfg: &Config, ops: I)
-        -> Scan<Constructor<I, ASTBuilder, ASTNode, fn(&mut ASTBuilder, &mut Option<ASTNode>, ASTOperation) -> Option<ASTNode>>, &Config, fn(&mut &Config, ASTNode) -> Option<ASTNode>>
+    pub fn build<I: Iterator<Item=ASTOperation>>(cfg: Config, ops: I)
+        -> Scan<Constructor<I, ASTBuilder, ASTNode, fn(&mut ASTBuilder, &mut Option<ASTNode>, ASTOperation) -> Option<ASTNode>>, Config, fn(&mut Config, ASTNode) -> Option<ASTNode>>
         //concrete return type because of optimization reasons. Read and use it as "Iterator<ASTNode>"
     {
         ops.construct_state(ASTBuilder::new(),
@@ -52,10 +52,10 @@ impl ASTBuilder {
             construct as fn(&mut ASTBuilder, &mut Option<ASTNode>, ASTOperation) -> Option<ASTNode> //necessary cast is a known bug
         }).scan(cfg,
             {
-                fn scan(cfg: &mut &Config, x: ASTNode) -> Option<ASTNode>
+                fn scan(cfg: &mut Config, x: ASTNode) -> Option<ASTNode>
                 {
                     let mut y = x.clone();
-                    y.parse_expressions(*cfg);
+                    y.parse_expressions(cfg);
                     Some(y)
                 }
                 scan
@@ -348,13 +348,13 @@ mod tests {
     fn test_ast(input: &str) -> Vec<ASTNode> {
         let cfg = Config::default_config();
         let mut cursor: Cursor<Vec<u8>> = Cursor::new(input.to_string().into_bytes());
-        let tokens = lexer::lex(&cfg, &mut cursor);
-        let parser = parser::Parser::new(&cfg);
+        let tokens = lexer::lex(cfg.clone(), &mut cursor);
+        let parser = parser::Parser::new(cfg.clone());
         let ast_ops = parser.parse(tokens.inspect(|ref token| {
             println!("{:?}", token);
         }));
 
-        let ast = ASTBuilder::build(&cfg, ast_ops);
+        let ast = ASTBuilder::build(cfg, ast_ops);
         ast.collect()
     }
 

--- a/src/zwreec/frontend/lexer.rs
+++ b/src/zwreec/frontend/lexer.rs
@@ -40,8 +40,8 @@ pub enum LexerError {
 ///
 /// The `zwreec::utils::extensions` module defines a new iterator `FilteringScan`.
 /// This struct stores the state for this iterator.
-pub struct ScanState<'a> {
-    cfg: &'a Config,
+pub struct ScanState {
+    cfg: Config,
     current_text: String,
     current_text_location: (u64, u64),
     skip_next: bool,
@@ -63,10 +63,10 @@ pub struct ScanState<'a> {
 /// let cfg = zwreec::config::Config::default_config();
 /// let mut input = Cursor::new("::Start\nHello World".to_string().into_bytes());
 ///
-/// let tokens = zwreec::frontend::lexer::lex(&cfg, &mut input);
+/// let tokens = zwreec::frontend::lexer::lex(cfg, &mut input);
 /// ```
 #[allow(unused_variables)]
-pub fn lex<'a, R: Read>(cfg: &'a Config, input: &'a mut R) -> FilteringScan<Peeking<TweeLexer<BufReader<&'a mut R>>, Token>, ScanState<'a>, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
+pub fn lex<R: Read>(cfg: Config, input: R) -> FilteringScan<Peeking<TweeLexer<BufReader<R>>, Token>, ScanState, fn(&mut ScanState, (Token, Option<Token>)) -> Option<Token>>  {
 
     let mut lexer = TweeLexer::new(BufReader::new(input));
     lexer.cfg = Some(cfg.clone());
@@ -372,7 +372,7 @@ mod tests {
     fn test_lex(input: &str) -> Vec<Token> {
         let cfg = Config::default_config();
         let mut cursor: Cursor<Vec<u8>> = Cursor::new(input.to_string().into_bytes());
-        lex(&cfg, &mut cursor).collect()
+        lex(cfg, &mut cursor).collect()
     }
 
     fn assert_tok_eq(expected: Vec<Token>, tokens: Vec<Token>) {

--- a/src/zwreec/frontend/mod.rs
+++ b/src/zwreec/frontend/mod.rs
@@ -17,11 +17,11 @@
 //! let mut twee = Cursor::new("::Start\nHello World".to_string().into_bytes());
 //!
 //! // Generate Token Stream
-//! let tokens = zwreec::frontend::lexer::lex(&cfg, &mut twee);
+//! let tokens = zwreec::frontend::lexer::lex(cfg.clone(), &mut twee);
 //!
 //! // Parse Tokens
-//! let p = zwreec::frontend::parser::Parser::new(&cfg);
-//! let ast: Vec<zwreec::frontend::ast::ASTNode> = zwreec::frontend::ast::ASTBuilder::build(&cfg, p.parse(tokens)).collect();
+//! let p = zwreec::frontend::parser::Parser::new(cfg.clone());
+//! let ast: Vec<zwreec::frontend::ast::ASTNode> = zwreec::frontend::ast::ASTBuilder::build(cfg, p.parse(tokens)).collect();
 //! ```
 
 pub mod ast;


### PR DESCRIPTION
Letztes Feature von mir vorm Feature-Freeze.
(ZFile Refactor wird nichts mehr. Ihr lest echt von der schon geschriebenen ZFile auch noch... Das Seek Trait kann man ja noch implementieren, aber Read geht nicht mehr, wegen stdout..)

Man beachte die 20 Zeilen, die in extensions.rs die eigentliche Funktionalität alleine bereitstellen.

Der Rest ist Fixing von Tests oder Config nicht mehr als Referenz weiterzugeben. Ist zwar (theoretisch) minimal inperformanter, aber nötig, weil ein Thread theoretisch länger leben kann. Die Lösung wäre ein ScopedThread aber die sind noch unstable, also muss Config länger leben können als der Main-Thread, auch wenn ich am Ende joine.

Ich habe das ganze mit abyss_final2.twee gegen den aktuellen master gebenchmarkt, weil das unsere längste Beispieldatei ist. Der Performance-Zuwachs beläuft sich auf 50-100 millisekunden im Durchschnitt nach vielen Durchläufen.

Die gute Nachricht ist, es ist im Durchschnitt bei kurzen Dateien nicht langsamer.

Also auch wenns reichlich irrelevant ist, ist es ein cooles Feature zum Angeben in der Präsentation und es funktioniert.
Wenn jemand möchte kann ich das gerne auch zu einem Feature-Flag umbauen, aber es besteht nicht wirklich ein Grund dazu.
